### PR TITLE
Feat: Update Regionalization Button and Regionalization Bar to show the postal code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
 - Integrates with search.query event api (#2)
 - Applies new local tokens to `Badge` (#462)
 - Applies new local tokens to `Hero` (#435)
@@ -19,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update `RegionalizationButton` and `RegionalizationBar` to show the postal code (#8)
 - Changed name from BaseStore to GatsbyStore (#497)
 - Applies new local tokens to `BannerText` (#470)
 - Update the Incentives component to handle CMS data (#474)

--- a/src/components/regionalization/RegionalizationBar/RegionalizationBar.tsx
+++ b/src/components/regionalization/RegionalizationBar/RegionalizationBar.tsx
@@ -2,26 +2,26 @@ import type { HTMLAttributes } from 'react'
 import { useModal } from 'src/sdk/ui/modal/Provider'
 import Button from 'src/components/ui/Button'
 import Icon from 'src/components/ui/Icon'
+import { useSession } from '@faststore/sdk'
 
 interface RegionalizationBarProps extends HTMLAttributes<HTMLDivElement> {
-  content?: string
   classes: string
 }
 
 export default function RegionalizationBar({
-  content,
   classes,
   ...otherProps
 }: RegionalizationBarProps) {
   const { setIsRegionalizationModalOpen } = useModal()
+  const { postalCode } = useSession()
 
   return (
     <div data-fs-regionalization-bar className={classes} {...otherProps}>
       <Button onClick={() => setIsRegionalizationModalOpen(true)}>
         <Icon name="MapPin" width={24} height={24} />
-        {content ? (
+        {postalCode ? (
           <>
-            <span>{content}</span>
+            <span>{postalCode}</span>
             <span>Edit</span>
           </>
         ) : (

--- a/src/components/regionalization/RegionalizationBar/RegionalizationBar.tsx
+++ b/src/components/regionalization/RegionalizationBar/RegionalizationBar.tsx
@@ -21,11 +21,11 @@ export default function RegionalizationBar({
         <Icon name="MapPin" width={24} height={24} />
         {postalCode ? (
           <>
-            <span>{postalCode}</span>
+            <span key="postal-code-mobile">{postalCode}</span>
             <span>Edit</span>
           </>
         ) : (
-          <span>Set your location</span>
+          <span key="default-postal-code-mobile">Set your location</span>
         )}
         <Icon name="CaretRight" width={24} height={24} />
       </Button>

--- a/src/components/regionalization/RegionalizationBar/RegionalizationBar.tsx
+++ b/src/components/regionalization/RegionalizationBar/RegionalizationBar.tsx
@@ -25,7 +25,7 @@ export default function RegionalizationBar({
             <span>Edit</span>
           </>
         ) : (
-          <span key="default-postal-code-mobile">Set your location</span>
+          <span key="postal-code-mobile">Set your location</span>
         )}
         <Icon name="CaretRight" width={24} height={24} />
       </Button>

--- a/src/components/regionalization/RegionalizationBar/RegionalizationBar.tsx
+++ b/src/components/regionalization/RegionalizationBar/RegionalizationBar.tsx
@@ -21,11 +21,11 @@ export default function RegionalizationBar({
         <Icon name="MapPin" width={24} height={24} />
         {postalCode ? (
           <>
-            <span key="postal-code-mobile">{postalCode}</span>
+            <span>{postalCode}</span>
             <span>Edit</span>
           </>
         ) : (
-          <span key="postal-code-mobile">Set your location</span>
+          <span>Set your location</span>
         )}
         <Icon name="CaretRight" width={24} height={24} />
       </Button>

--- a/src/components/regionalization/RegionalizationButton/RegionalizationButton.tsx
+++ b/src/components/regionalization/RegionalizationButton/RegionalizationButton.tsx
@@ -2,18 +2,18 @@ import type { HTMLAttributes } from 'react'
 import { useModal } from 'src/sdk/ui/modal/Provider'
 import Button from 'src/components/ui/Button'
 import Icon from 'src/components/ui/Icon'
+import { useSession } from '@faststore/sdk'
 
 interface RegionalizationButtonProps extends HTMLAttributes<HTMLDivElement> {
-  content?: string
   classes: string
 }
 
 export default function RegionalizationButton({
-  content,
   classes,
   ...otherProps
 }: RegionalizationButtonProps) {
   const { setIsRegionalizationModalOpen } = useModal()
+  const { postalCode } = useSession()
 
   return (
     <div data-fs-regionalization-button className={classes} {...otherProps}>
@@ -24,9 +24,9 @@ export default function RegionalizationButton({
         iconPosition="left"
         onClick={() => setIsRegionalizationModalOpen(true)}
       >
-        {content ? (
+        {postalCode ? (
           <>
-            <span>{content}</span>
+            <span>{postalCode}</span>
           </>
         ) : (
           <span>Set your location</span>

--- a/src/components/regionalization/RegionalizationButton/RegionalizationButton.tsx
+++ b/src/components/regionalization/RegionalizationButton/RegionalizationButton.tsx
@@ -25,11 +25,9 @@ export default function RegionalizationButton({
         onClick={() => setIsRegionalizationModalOpen(true)}
       >
         {postalCode ? (
-          <>
-            <span>{postalCode}</span>
-          </>
+          <span key="postal-code-desktop">{postalCode}</span>
         ) : (
-          <span>Set your location</span>
+          <span key="default-postal-code-desktop">Set your location</span>
         )}
       </Button>
     </div>

--- a/src/components/regionalization/RegionalizationButton/RegionalizationButton.tsx
+++ b/src/components/regionalization/RegionalizationButton/RegionalizationButton.tsx
@@ -24,11 +24,9 @@ export default function RegionalizationButton({
         iconPosition="left"
         onClick={() => setIsRegionalizationModalOpen(true)}
       >
-        {postalCode ? (
-          <span key="postal-code-desktop">{postalCode}</span>
-        ) : (
-          <span key="default-postal-code-desktop">Set your location</span>
-        )}
+        <span key="postal-code-desktop">
+          {postalCode ?? 'Set your location'}
+        </span>
       </Button>
     </div>
   )

--- a/src/components/regionalization/RegionalizationButton/RegionalizationButton.tsx
+++ b/src/components/regionalization/RegionalizationButton/RegionalizationButton.tsx
@@ -24,9 +24,7 @@ export default function RegionalizationButton({
         iconPosition="left"
         onClick={() => setIsRegionalizationModalOpen(true)}
       >
-        <span key="postal-code-desktop">
-          {postalCode ?? 'Set your location'}
-        </span>
+        <span>{postalCode ?? 'Set your location'}</span>
       </Button>
     </div>
   )


### PR DESCRIPTION
Applies patch from https://github.com/vtex-sites/base.store/pull/495

## What's the purpose of this pull request?

Update Regionalization Button and Regionalization Bar to show the last postal code saved, instead of receiving a `content` prop.

![image](https://user-images.githubusercontent.com/22377378/164786815-d827a559-91a7-41f8-897a-c1ef966bc1cd.png)

![image](https://user-images.githubusercontent.com/22377378/164786782-aec331e0-c7d3-44dd-9110-85c161f73288.png)

## How to test it?

1- Set a valid postal code in `RegionalizationInput` 
2- Press "enter" key
3- Push the close button.

## References

- [Base store's PR](https://github.com/vtex-sites/base.store/pull/495)
- [Postal Code Bar's original code](https://github.com/vtex-sites/base.store/pull/424)

## Checklist

- [x] CHANGELOG entry added
