### PR TITLE
chore: home performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adds Storybook configs (#463)
 - Adds vtex search tracking script. With this we will populate TopSearches and Autocomplete indices (#389)
 - Add `RegionalizationBar`, `RegionalizationButton` components and integrates it on Mobile and Desktop devices (#424).
+- Suspend the useProductsQuery, the ProductShelves and ProductTiles ([#10](https://github.com/vtex-sites/gatsby.store/pull/10)).
 
 ### Changed
 
@@ -32,7 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixes `ProductCard` bordered variant (#5)
 - Changed name from BaseStore to GatsbyStore (#497)
 - Applies new local tokens to `BannerText` (#470)
-- Update the Incentives component to handle CMS data (#474)
+- Update the Incentives component to handle CMS data (#474).
+- useQuery, at usePersonQuery, in favor of `request` ([#10](https://github.com/vtex-sites/gatsby.store/pull/10)).
 
 ### Deprecated
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node": ">=14"
   },
   "dependencies": {
-    "@builder.io/partytown": "^0.5.1",
+    "@builder.io/partytown": "^0.5.3",
     "@envelop/core": "^1.2.0",
     "@envelop/graphql-jit": "^1.1.1",
     "@envelop/parser-cache": "^2.2.0",

--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -4,7 +4,6 @@ import Footer from 'src/components/common/Footer'
 import Navbar from 'src/components/common/Navbar'
 import Toast from 'src/components/common/Toast'
 import RegionalizationBar from 'src/components/regionalization/RegionalizationBar'
-import RegionalizationModal from 'src/components/regionalization/RegionalizationModal'
 import { useUI } from 'src/sdk/ui'
 import type { PropsWithChildren } from 'react'
 import { useModal } from 'src/sdk/ui/modal/Provider'
@@ -12,6 +11,9 @@ import { useModal } from 'src/sdk/ui/modal/Provider'
 import 'src/styles/pages/layout.scss'
 
 const CartSidebar = lazy(() => import('src/components/cart/CartSidebar'))
+const RegionalizationModal = lazy(
+  () => import('src/components/regionalization/RegionalizationModal')
+)
 
 function Layout({ children }: PropsWithChildren<unknown>) {
   const { displayMinicart } = useUI()
@@ -42,10 +44,14 @@ function Layout({ children }: PropsWithChildren<unknown>) {
           </Suspense>
         )}
       </div>
-      <RegionalizationModal
-        isOpen={isRegionalizationModalOpen}
-        onDismiss={() => setIsRegionalizationModalOpen(false)}
-      />
+      {isRegionalizationModalOpen && (
+        <Suspense fallback={null}>
+          <RegionalizationModal
+            isOpen={isRegionalizationModalOpen}
+            onDismiss={() => setIsRegionalizationModalOpen(false)}
+          />
+        </Suspense>
+      )}
     </>
   )
 }

--- a/src/components/sections/ProductShelf/ProductShelf.tsx
+++ b/src/components/sections/ProductShelf/ProductShelf.tsx
@@ -8,6 +8,7 @@ import Section from '../Section'
 interface ProductShelfProps extends Partial<ProductsQueryQueryVariables> {
   title: string | JSX.Element
   withDivisor?: boolean
+  suspenseData?: boolean
 }
 
 const options = {
@@ -18,9 +19,13 @@ const options = {
 function ProductShelf({
   title,
   withDivisor = false,
+  suspenseData,
   ...variables
 }: ProductShelfProps) {
-  const products = useProductsQuery(variables, options)
+  const products = useProductsQuery(
+    variables,
+    suspenseData ? options : undefined
+  )
 
   if (products?.edges.length === 0) {
     return null

--- a/src/components/sections/ProductShelf/ProductShelf.tsx
+++ b/src/components/sections/ProductShelf/ProductShelf.tsx
@@ -10,12 +10,17 @@ interface ProductShelfProps extends Partial<ProductsQueryQueryVariables> {
   withDivisor?: boolean
 }
 
+const options = {
+  suspense: true,
+  fallbackData: { search: { products: undefined } },
+}
+
 function ProductShelf({
   title,
   withDivisor = false,
   ...variables
 }: ProductShelfProps) {
-  const products = useProductsQuery(variables)
+  const products = useProductsQuery(variables, options)
 
   if (products?.edges.length === 0) {
     return null

--- a/src/components/sections/ProductTiles/ProductTiles.tsx
+++ b/src/components/sections/ProductTiles/ProductTiles.tsx
@@ -27,8 +27,13 @@ const getRatio = (products: number, idx: number) => {
   return 3 / 4
 }
 
+const options = {
+  suspense: true,
+  fallbackData: { search: { products: undefined } },
+}
+
 const ProductTiles = ({ title, ...variables }: TilesProps) => {
-  const products = useProductsQuery(variables)
+  const products = useProductsQuery(variables, options)
 
   if (products?.edges.length === 0) {
     return null

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -2,7 +2,7 @@ import { parseSearchState, SearchProvider, useSession } from '@faststore/sdk'
 import { gql } from '@vtex/graphql-utils'
 import { graphql } from 'gatsby'
 import { BreadcrumbJsonLd, GatsbySeo } from 'gatsby-plugin-next-seo'
-import { Suspense, useMemo } from 'react'
+import { useMemo } from 'react'
 import Breadcrumb from 'src/components/sections/Breadcrumb'
 import Hero from 'src/components/sections/Hero'
 import ProductGallery from 'src/components/sections/ProductGallery'
@@ -19,7 +19,6 @@ import type {
 } from '@generated/graphql'
 import type { PageProps } from 'gatsby'
 import type { SearchState } from '@faststore/sdk'
-import ProductShelfSkeleton from 'src/components/skeletons/ProductShelfSkeleton'
 
 import 'src/styles/pages/plp.scss'
 
@@ -123,14 +122,12 @@ function Page(props: Props) {
 
       <ProductGallery title={title} />
 
-      <Suspense fallback={<ProductShelfSkeleton loading />}>
-        <ProductShelf
-          first={ITEMS_PER_SECTION}
-          sort="score_desc"
-          title="You might also like"
-          withDivisor
-        />
-      </Suspense>
+      <ProductShelf
+        first={ITEMS_PER_SECTION}
+        sort="score_desc"
+        title="You might also like"
+        withDivisor
+      />
 
       <ScrollToTopButton />
     </SearchProvider>

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -2,7 +2,7 @@ import { parseSearchState, SearchProvider, useSession } from '@faststore/sdk'
 import { gql } from '@vtex/graphql-utils'
 import { graphql } from 'gatsby'
 import { BreadcrumbJsonLd, GatsbySeo } from 'gatsby-plugin-next-seo'
-import { useMemo } from 'react'
+import { Suspense, useMemo } from 'react'
 import Breadcrumb from 'src/components/sections/Breadcrumb'
 import Hero from 'src/components/sections/Hero'
 import ProductGallery from 'src/components/sections/ProductGallery'
@@ -19,6 +19,7 @@ import type {
 } from '@generated/graphql'
 import type { PageProps } from 'gatsby'
 import type { SearchState } from '@faststore/sdk'
+import ProductShelfSkeleton from 'src/components/skeletons/ProductShelfSkeleton'
 
 import 'src/styles/pages/plp.scss'
 
@@ -122,12 +123,14 @@ function Page(props: Props) {
 
       <ProductGallery title={title} />
 
-      <ProductShelf
-        first={ITEMS_PER_SECTION}
-        sort="score_desc"
-        title="You might also like"
-        withDivisor
-      />
+      <Suspense fallback={<ProductShelfSkeleton loading />}>
+        <ProductShelf
+          first={ITEMS_PER_SECTION}
+          sort="score_desc"
+          title="You might also like"
+          withDivisor
+        />
+      </Suspense>
 
       <ScrollToTopButton />
     </SearchProvider>

--- a/src/pages/[slug]/p.tsx
+++ b/src/pages/[slug]/p.tsx
@@ -16,8 +16,7 @@ import type {
   ProductPageQueryQueryVariables,
 } from '@generated/graphql'
 import { ITEMS_PER_SECTION } from 'src/constants'
-import { Suspense } from 'react'
-import ProductShelfSkeleton from 'src/components/skeletons/ProductShelfSkeleton'
+
 import 'src/styles/pages/pdp.scss'
 
 export type Props = PageProps<
@@ -102,14 +101,12 @@ function Page(props: Props) {
       */}
       <ProductDetails product={product} />
 
-      <Suspense fallback={<ProductShelfSkeleton loading />}>
-        <ProductShelf
-          first={ITEMS_PER_SECTION}
-          term={product.brand.name}
-          title="You might also like"
-          withDivisor
-        />
-      </Suspense>
+      <ProductShelf
+        first={ITEMS_PER_SECTION}
+        term={product.brand.name}
+        title="You might also like"
+        withDivisor
+      />
     </>
   )
 }

--- a/src/pages/[slug]/p.tsx
+++ b/src/pages/[slug]/p.tsx
@@ -16,7 +16,8 @@ import type {
   ProductPageQueryQueryVariables,
 } from '@generated/graphql'
 import { ITEMS_PER_SECTION } from 'src/constants'
-
+import { Suspense } from 'react'
+import ProductShelfSkeleton from 'src/components/skeletons/ProductShelfSkeleton'
 import 'src/styles/pages/pdp.scss'
 
 export type Props = PageProps<
@@ -99,15 +100,16 @@ function Page(props: Props) {
         If needed, wrap your component in a <Section /> component
         (not the HTML tag) before rendering it here.
       */}
+      <Suspense fallback={<ProductShelfSkeleton loading />}>
+        <ProductShelf
+          first={ITEMS_PER_SECTION}
+          term={product.brand.name}
+          title="You might also like"
+          withDivisor
+        />
+      </Suspense>
 
       <ProductDetails product={product} />
-
-      <ProductShelf
-        first={ITEMS_PER_SECTION}
-        term={product.brand.name}
-        title="You might also like"
-        withDivisor
-      />
     </>
   )
 }

--- a/src/pages/[slug]/p.tsx
+++ b/src/pages/[slug]/p.tsx
@@ -100,6 +100,8 @@ function Page(props: Props) {
         If needed, wrap your component in a <Section /> component
         (not the HTML tag) before rendering it here.
       */}
+      <ProductDetails product={product} />
+
       <Suspense fallback={<ProductShelfSkeleton loading />}>
         <ProductShelf
           first={ITEMS_PER_SECTION}
@@ -108,8 +110,6 @@ function Page(props: Props) {
           withDivisor
         />
       </Suspense>
-
-      <ProductDetails product={product} />
     </>
   )
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -11,6 +11,9 @@ import { ITEMS_PER_SECTION } from 'src/constants'
 import type { PageProps } from 'gatsby'
 import type { HomePageQueryQuery } from '@generated/graphql'
 import IncentivesMock from 'src/components/sections/Incentives/incentivesMock'
+import ProductShelfSkeleton from 'src/components/skeletons/ProductShelfSkeleton'
+import { Suspense } from 'react'
+import ProductTilesSkeleton from 'src/components/skeletons/ProductTilesSkeleton'
 
 import 'src/styles/pages/homepage.scss'
 
@@ -78,17 +81,21 @@ function Page(props: Props) {
 
       <IncentivesHeader incentives={IncentivesMock} />
 
-      <ProductShelf
-        first={ITEMS_PER_SECTION}
-        selectedFacets={[{ key: 'productClusterIds', value: '140' }]}
-        title="Most Wanted"
-      />
+      <Suspense fallback={<ProductShelfSkeleton loading />}>
+        <ProductShelf
+          first={ITEMS_PER_SECTION}
+          selectedFacets={[{ key: 'productClusterIds', value: '140' }]}
+          title="Most Wanted"
+        />
+      </Suspense>
 
-      <ProductTiles
-        first={3}
-        selectedFacets={[{ key: 'productClusterIds', value: '141' }]}
-        title="Just Arrived"
-      />
+      <Suspense fallback={<ProductTilesSkeleton loading />}>
+        <ProductTiles
+          first={3}
+          selectedFacets={[{ key: 'productClusterIds', value: '141' }]}
+          title="Just Arrived"
+        />
+      </Suspense>
 
       <BannerText
         title="Receive our news and promotions in advance. Enjoy and get 10% off on your first purchase."
@@ -96,11 +103,13 @@ function Page(props: Props) {
         actionLabel="Call to action"
       />
 
-      <ProductShelf
-        first={ITEMS_PER_SECTION}
-        selectedFacets={[{ key: 'productClusterIds', value: '142' }]}
-        title="Deals & Promotions"
-      />
+      <Suspense fallback={<ProductShelfSkeleton loading />}>
+        <ProductShelf
+          first={ITEMS_PER_SECTION}
+          selectedFacets={[{ key: 'productClusterIds', value: '142' }]}
+          title="Deals & Promotions"
+        />
+      </Suspense>
     </>
   )
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -86,6 +86,7 @@ function Page(props: Props) {
           first={ITEMS_PER_SECTION}
           selectedFacets={[{ key: 'productClusterIds', value: '140' }]}
           title="Most Wanted"
+          suspenseData
         />
       </Suspense>
 
@@ -108,6 +109,7 @@ function Page(props: Props) {
           first={ITEMS_PER_SECTION}
           selectedFacets={[{ key: 'productClusterIds', value: '142' }]}
           title="Deals & Promotions"
+          suspenseData
         />
       </Suspense>
     </>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1681,10 +1681,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@builder.io/partytown@^0.5.1":
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/@builder.io/partytown/-/partytown-0.5.1.tgz#89373ff8c424c60e1b61dc9029b31b9f9d5ece56"
-  integrity sha512-Qs1CrHTT/I1xeNlPn6+KSxhQhvcJKv2mZhesLfEeEftRbCWb3TdXIghNNIxrnAmD7Sivdp8dSOGEAcM8BLybDA==
+"@builder.io/partytown@^0.5.3":
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/@builder.io/partytown/-/partytown-0.5.3.tgz#29f06a1ef648c0cc8676ef70a2010b086578d177"
+  integrity sha512-8DBfUd1aGrIqASRjM/GnoIC1FM5V03GqKb4hFDwQ6Ug+0qqt1zVWhFRyNbDlXzWC411kNH7Y8zlDG66OBSJDEA==
 
 "@bundle-stats/cli-utils@^3.3.0":
   version "3.3.0"


### PR DESCRIPTION
## What's the purpose of this pull request?
One of the main problems of the home page that impacts the performance is the total blocking time (TBT).
This PR tries to decrease the TBT and improve the performance score overall on the home page.

## How does it work?
The highest task is the react first render. So investigating the components that have the most impact on this huge task, I discovered that the first component that uses the hook `useSWR` suffers from the compilation code from SWR and we can't avoid, but can delay. This component is the ButtonSignIn, that has usePersonQuery, that uses the useQuery.
As you can see, the self time is ~0, the rest comes from useSWR.
![image](https://user-images.githubusercontent.com/15680320/165979109-8b244796-7d6c-45ca-8c8c-5da7b94d839b.png)

Also, this PR suspends the ProductShelf and ProductTiles queries, so these components are removed from the first render, because of the task that contains the first render decrease the duration.

After these changes, this PR achieves these results
- ✅  the score increased from ~84 to ~90,
- ✅  the TBT decreased ~30%,
- ✅  the TTI decreased ~10%,
- ✅  the LCP increased ~16%,
- ✅  Speed index decreased ~18%,

Those results above come from the data below.

The result of 30 PSI test on mobile for each page
Page result - https://gatsby.vtex.app/ - at https://github.com/vtex-sites/gatsby.store/commit/b06bd2c58ed940bf7998adb91f208c267c3ba7f2
| Metric | Mean | Standard deviation | Confidence Interval (95%) |
|--------|--------|--------|--------|
| Cumulative Layout shift (CLS) | 0.01 | 0.00 | [0.01, 0.01] |
| First Contentful Paint (FCP) | 1688.45 | 3642.63 | [384.95, 2991.95] |
| Largest Contentful Paint (LCP) | 2328.17 | 12591.81 | [-2177.75, 6834.09] |
| Time to Interactive (TTI) | 3196.60 | 45061.14 | [-12928.32, 19321.52] |
| Total Blocking Time (TBT) | 508.97 | 11935.71 | [-12928.32, 19321.52] |
| Performance score | 0.839 | 0.001166 | [0.838916, 0.839751] |
| JavaScript Execution Time | 1534.87 | 30944.71 | [-9538.55, 12608.29] |
| Speed Index | 1753.65 | 8809.73 | [-1398.87, 4906.17] |

Page result - https://sfj-ce42e8a--gatsby.preview.vtex.app/
| Metric | Mean | Standard deviation | Confidence Interval (95%) |
|--------|--------|--------|--------|
| Cumulative Layout shift (CLS) | 0.01 | 0.00 | [0.01, 0.01] |
| First Contentful Paint (FCP) | 1501.17 | 22124.27 | [-6415.90, 9418.24] |
| Largest Contentful Paint (LCP) | 1937.10 | 38054.16 | [-11680.41, 15554.60] |
| Time to Interactive (TTI) | 2879.64 | 26718.59 | [-6681.48, 12440.77] |
| Total Blocking Time (TBT) | 354.02 | 4851.92 | [-6681.48, 12440.77] |
| Performance score | 0.901 | 0.000572 | [0.901129, 0.901538] |
| JavaScript Execution Time | 1271.81 | 32816.32 | [-10471.36, 13014.98] |
| Speed Index | 1563.31 | 61181.23 | [-20330.12, 23456.73] |

## How to test it?
Open the home page, test it, also test the performance score.
