### PR TITLE
feat: Adds new tokens to Select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+- Applies new local tokens to `Select` ([#17](https://github.com/vtex-sites/gatsby.store/pull/17))
 - Applies new local tokens to `Input Text` ([#15](https://github.com/vtex-sites/gatsby.store/pull/15))
 - `Toggle` component ([#14](https://github.com/vtex-sites/gatsby.store/pull/14))
 - Applies new local tokens to `Link` ([#19](https://github.com/vtex-sites/gatsby.store/pull/19))

--- a/src/components/search/Sort/Sort.tsx
+++ b/src/components/search/Sort/Sort.tsx
@@ -24,7 +24,7 @@ function Sort() {
     <Select
       id="sort-select"
       className="sort / text__title-mini-alt"
-      labelText="Sort by"
+      label="Sort by"
       options={OptionsMap}
       onChange={(e) => setSort(keys[e.target.selectedIndex])}
       value={sort}

--- a/src/components/ui/Select/Select.stories.tsx
+++ b/src/components/ui/Select/Select.stories.tsx
@@ -17,4 +17,5 @@ Default.args = {
     name_desc: 'Name, Z-A',
   },
   label: 'Label',
+  disabled: false,
 }

--- a/src/components/ui/Select/Select.stories.tsx
+++ b/src/components/ui/Select/Select.stories.tsx
@@ -1,0 +1,20 @@
+import type { SelectProps } from '.'
+import Select from '.'
+
+export default {
+  component: Select,
+  title: 'Atoms/Select',
+}
+
+const Template = ({ ...args }: SelectProps) => <Select {...args} />
+
+export const Default = Template.bind({})
+
+Default.args = {
+  id: 'select',
+  options: {
+    name_asc: 'Name, A-Z',
+    name_desc: 'Name, Z-A',
+  },
+  label: 'Label',
+}

--- a/src/components/ui/Select/Select.tsx
+++ b/src/components/ui/Select/Select.tsx
@@ -30,6 +30,7 @@ export default function Select({
   value,
   'aria-label': ariaLabel,
   testId,
+  ...otherProps
 }: UISelectProps) {
   return (
     <div data-fs-select className={className}>
@@ -44,6 +45,7 @@ export default function Select({
         value={value}
         aria-label={ariaLabel}
         id={id}
+        {...otherProps}
       >
         {Object.keys(options).map((key) => (
           <option key={key} value={key}>

--- a/src/components/ui/Select/Select.tsx
+++ b/src/components/ui/Select/Select.tsx
@@ -1,8 +1,8 @@
-import { Select as UISelect } from '@faststore/ui'
+import { Select as UISelect, Label as UILabel } from '@faststore/ui'
 import Icon from 'src/components/ui/Icon'
 import type { SelectProps } from '@faststore/ui'
 
-interface UISelectProps extends SelectProps {
+export interface UISelectProps extends SelectProps {
   /*
    * Redefines the id property to be required when using the Select component. The
    * id will be used to link the UISelect component and its label.
@@ -18,7 +18,7 @@ interface UISelectProps extends SelectProps {
    * Specifies the text that will be displayed in the label right next to the Select.
    * If omitted, the label will not be rendered.
    */
-  labelText?: string
+  label?: string
 }
 
 export default function Select({
@@ -26,14 +26,18 @@ export default function Select({
   className,
   options,
   onChange,
-  labelText,
+  label,
   value,
   'aria-label': ariaLabel,
   testId,
 }: UISelectProps) {
   return (
-    <div data-select className={className}>
-      {labelText && <label htmlFor={id}>{labelText}</label>}
+    <div data-fs-select className={className}>
+      {label && (
+        <UILabel data-fs-select-label htmlFor={id}>
+          {label}
+        </UILabel>
+      )}
       <UISelect
         data-testid={testId}
         onChange={onChange}
@@ -47,7 +51,13 @@ export default function Select({
           </option>
         ))}
       </UISelect>
-      <Icon name="CaretDown" width={18} height={18} weight="bold" />
+      <Icon
+        data-fs-select-icon
+        name="CaretDown"
+        width={18}
+        height={18}
+        weight="bold"
+      />
     </div>
   )
 }

--- a/src/components/ui/Select/index.ts
+++ b/src/components/ui/Select/index.ts
@@ -1,0 +1,2 @@
+export { default } from './Select'
+export type { UISelectProps as SelectProps } from './Select'

--- a/src/components/ui/Select/index.tsx
+++ b/src/components/ui/Select/index.tsx
@@ -1,1 +1,0 @@
-export { default } from './Select'

--- a/src/components/ui/Select/select.scss
+++ b/src/components/ui/Select/select.scss
@@ -17,9 +17,9 @@
   --fs-select-bkg-color-focus             : var(--fs-color-primary-bkg-light);
   --fs-select-bkg-color-hover             : var(--fs-select-bkg-color-focus);
 
-  --fs-toggle-transition-timing           : var(--fs-transition-timing);
-  --fs-toggle-transition-property         : var(--fs-transition-property);
-  --fs-toggle-transition-function         : var(--fs-transition-function);
+  --fs-select-transition-timing           : var(--fs-transition-timing);
+  --fs-select-transition-property         : var(--fs-transition-property);
+  --fs-select-transition-function         : var(--fs-transition-function);
 
   --fs-select-label-color                 : var(--fs-color-text-light);
   --fs-select-label-margin-right          : var(--fs-spacing-1);
@@ -42,7 +42,7 @@
     border: 0;
     border-radius: var(--fs-select-border-radius);
     box-shadow: 0;
-    transition: var(--fs-toggle-transition-property) var(--fs-toggle-transition-timing) var(--fs-toggle-transition-function);
+    transition: var(--fs-select-transition-property) var(--fs-select-transition-timing) var(--fs-select-transition-function);
     appearance: none;
 
     @include focus-ring-visible;

--- a/src/components/ui/Select/select.scss
+++ b/src/components/ui/Select/select.scss
@@ -24,7 +24,7 @@
   --fs-select-label-color                 : var(--fs-color-text-light);
   --fs-select-label-margin-right          : var(--fs-spacing-1);
 
-  --fs-select-icon-right                  : var(--fs-spacing-2);
+  --fs-select-icon-position-right         : var(--fs-spacing-2);
   --fs-select-icon-color                  : var(--fs-color-link);
 
   // Disabled
@@ -71,7 +71,7 @@
 
 [data-fs-select-icon] {
   position: absolute;
-  right: var(--fs-select-icon-right);
+  right: var(--fs-select-icon-position-right);
   color: var(--fs-select-icon-color);
   pointer-events: none;
 }

--- a/src/components/ui/Select/select.scss
+++ b/src/components/ui/Select/select.scss
@@ -9,17 +9,20 @@
   --fs-select-height                      : var(--fs-spacing-6);
   --fs-select-min-height                  : var(--fs-control-tap-size);
   --fs-select-padding                     : var(--fs-spacing-1) var(--fs-spacing-5) var(--fs-spacing-1) var(--fs-spacing-2);
-  --fs-select-color                       : var(--fs-color-link);
-  --fs-select-bkg                         : transparent;
+
+  --fs-select-text-color                  : var(--fs-color-link);
   --fs-select-border-radius               : var(--fs-border-radius-default);
-  --fs-select-box-shadow-transition       : box-shadow var(--fs-transition-timing) ease;
-  --fs-select-background-color-transition : background-color var(--fs-transition-timing) ease;
   --fs-select-appearance                  : none;
+
+  --fs-select-bkg                         : transparent;
   --fs-select-bkg-color-focus             : var(--fs-color-primary-bkg-light);
   --fs-select-bkg-color-hover             : var(--fs-select-bkg-color-focus);
 
-  --fs-select-label-margin-right          : var(--fs-spacing-1);
+  --fs-select-box-shadow-transition       : box-shadow var(--fs-transition-timing) ease;
+  --fs-select-background-color-transition : background-color var(--fs-transition-timing) ease;
+
   --fs-select-label-color                 : var(--fs-color-text-light);
+  --fs-select-label-margin-right          : var(--fs-spacing-1);
 
   --fs-select-icon-right                  : var(--fs-spacing-2);
   --fs-select-icon-color                  : var(--fs-color-link);
@@ -34,7 +37,7 @@
 
   select {
     padding: var(--fs-select-padding);
-    color: var(--fs-select-color);
+    color: var(--fs-select-text-color);
     background: var(--fs-select-bkg);
     border: 0;
     border-radius: var(--fs-select-border-radius);

--- a/src/components/ui/Select/select.scss
+++ b/src/components/ui/Select/select.scss
@@ -1,47 +1,75 @@
 @import "src/styles/scaffold";
 
-[data-select] {
+[data-fs-select] {
+  // --------------------------------------------------------
+  // Design Tokens for Select
+  // --------------------------------------------------------
+
+  // Default properties
+  --fs-select-height                      : var(--fs-spacing-6);
+  --fs-select-min-height                  : var(--fs-control-tap-size);
+  --fs-select-padding                     : var(--fs-spacing-1) var(--fs-spacing-5) var(--fs-spacing-1) var(--fs-spacing-2);
+  --fs-select-color                       : var(--fs-color-link);
+  --fs-select-bkg                         : transparent;
+  --fs-select-border-radius               : var(--fs-border-radius-default);
+  --fs-select-box-shadow-transition       : box-shadow var(--fs-transition-timing) ease;
+  --fs-select-background-color-transition : background-color var(--fs-transition-timing) ease;
+  --fs-select-appearance                  : none;
+  --fs-select-bkg-color-focus             : var(--fs-color-primary-bkg-light);
+  --fs-select-bkg-color-hover             : var(--fs-select-bkg-color-focus);
+
+  --fs-select-label-margin-right          : var(--fs-spacing-1);
+  --fs-select-label-color                 : var(--fs-color-text-light);
+
+  --fs-select-icon-right                  : var(--fs-spacing-2);
+  --fs-select-icon-color                  : var(--fs-color-link);
+
+  // Disabled
+  --fs-select-disabled-color              : var(--fs-color-disabled-text);
+  --fs-select-disabled-opacity            : 1;
+
   position: relative;
   display: flex;
   align-items: center;
 
-  label {
-    margin-right: var(--fs-spacing-1);
-    color: var(--fs-color-text-light);
-  }
-
-  [data-store-select] {
-    padding: var(--fs-spacing-1) var(--fs-spacing-5) var(--fs-spacing-1) var(--fs-spacing-2);
-    color: var(--fs-color-link);
-    background: transparent;
+  select {
+    padding: var(--fs-select-padding);
+    color: var(--fs-select-color);
+    background: var(--fs-select-bkg);
     border: 0;
-    border-radius: var(--fs-border-radius-default);
+    border-radius: var(--fs-select-border-radius);
     box-shadow: 0;
-    transition: box-shadow .2s ease, background-color .2s ease;
-    appearance: none;
+    transition: var(--fs-select-box-shadow-transition);
+    transition: var(--fs-select-background-color-transition);
+    appearance: var(--fs-select-appearance);
 
     @include focus-ring-visible;
 
-    &:focus { background-color: var(--fs-color-primary-bkg-light); }
+    &:focus { background-color: var(--fs-select-bkg-color-focus); }
 
-    &:hover:not(:disabled) { background-color: var(--fs-color-primary-bkg-light); }
+    &:hover:not(:disabled) { background-color: var(--fs-select-bkg-color-hover); }
 
     &:disabled {
-      color: var(--fs-color-disabled-text);
+      color: var(--fs-select-disabled-color);
       cursor: not-allowed;
-      opacity: 1;
-      + svg { display: none; }
+      opacity: var(--fs-select-disabled-opacity);
+      + [data-fs-select-icon] { display: none; }
     }
 
-    @include media("<notebook") { min-height: var(--fs-control-tap-size); }
+    @include media("<notebook") { min-height: var(--fs-select-min-height); }
 
-    @include media(">=notebook") { height: var(--fs-spacing-6); }
+    @include media(">=notebook") { height: var(--fs-select-height); }
   }
+}
 
-  svg {
-    position: absolute;
-    right: var(--fs-spacing-2);
-    color: var(--fs-color-link);
-    pointer-events: none;
-  }
+[data-fs-select-label] {
+  margin-right: var(--fs-select-label-margin-right);
+  color: var(--fs-select-label-color);
+}
+
+[data-fs-select-icon] {
+  position: absolute;
+  right: var(--fs-select-icon-right);
+  color: var(--fs-select-icon-color);
+  pointer-events: none;
 }

--- a/src/components/ui/Select/select.scss
+++ b/src/components/ui/Select/select.scss
@@ -18,8 +18,9 @@
   --fs-select-bkg-color-focus             : var(--fs-color-primary-bkg-light);
   --fs-select-bkg-color-hover             : var(--fs-select-bkg-color-focus);
 
-  --fs-select-box-shadow-transition       : box-shadow var(--fs-transition-timing) ease;
-  --fs-select-background-color-transition : background-color var(--fs-transition-timing) ease;
+  --fs-toggle-transition-timing           : var(--fs-transition-timing);
+  --fs-toggle-transition-property         : var(--fs-transition-property);
+  --fs-toggle-transition-function         : var(--fs-transition-function);
 
   --fs-select-label-color                 : var(--fs-color-text-light);
   --fs-select-label-margin-right          : var(--fs-spacing-1);
@@ -42,8 +43,7 @@
     border: 0;
     border-radius: var(--fs-select-border-radius);
     box-shadow: 0;
-    transition: var(--fs-select-box-shadow-transition);
-    transition: var(--fs-select-background-color-transition);
+    transition: var(--fs-toggle-transition-property) var(--fs-toggle-transition-timing) var(--fs-toggle-transition-function);
     appearance: var(--fs-select-appearance);
 
     @include focus-ring-visible;

--- a/src/components/ui/Select/select.scss
+++ b/src/components/ui/Select/select.scss
@@ -12,7 +12,6 @@
 
   --fs-select-text-color                  : var(--fs-color-link);
   --fs-select-border-radius               : var(--fs-border-radius-default);
-  --fs-select-appearance                  : none;
 
   --fs-select-bkg                         : transparent;
   --fs-select-bkg-color-focus             : var(--fs-color-primary-bkg-light);
@@ -29,8 +28,8 @@
   --fs-select-icon-color                  : var(--fs-color-link);
 
   // Disabled
-  --fs-select-disabled-color              : var(--fs-color-disabled-text);
-  --fs-select-disabled-opacity            : 1;
+  --fs-select-disabled-text-color         : var(--fs-color-disabled-text);
+  --fs-select-disabled-text-opacity       : 1;
 
   position: relative;
   display: flex;
@@ -44,7 +43,7 @@
     border-radius: var(--fs-select-border-radius);
     box-shadow: 0;
     transition: var(--fs-toggle-transition-property) var(--fs-toggle-transition-timing) var(--fs-toggle-transition-function);
-    appearance: var(--fs-select-appearance);
+    appearance: none;
 
     @include focus-ring-visible;
 
@@ -53,9 +52,9 @@
     &:hover:not(:disabled) { background-color: var(--fs-select-bkg-color-hover); }
 
     &:disabled {
-      color: var(--fs-select-disabled-color);
+      color: var(--fs-select-disabled-text-color);
       cursor: not-allowed;
-      opacity: var(--fs-select-disabled-opacity);
+      opacity: var(--fs-select-disabled-text-opacity);
       + [data-fs-select-icon] { display: none; }
     }
 


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to add new tokens to the `Select` component using the [Theming Structure](https://github.com/vtex-sites/base.store/pull/407).

## How does it work?

This PR uses local variables to parameterize the `Select` properties, then connects these scoped tokens to the global ones.

### New global tokens:
None.

### New local tokens for `Select`:

#### Default properties:
| Local token | Default value/Global token linked |
| - | - | 
| `--fs-select-height` | `var(--fs-spacing-6)` |
| `--fs-select-min-height` | `var(--fs-control-tap-size)` |
| `--fs-select-padding` | `var(--fs-spacing-1) var(--fs-spacing-5) var(--fs-spacing-1) var(--fs-spacing-2)` |
|  |  |
| `--fs-select-text-color` | `var(--fs-color-link)` |
| `--fs-select-border-radius` | `var(--fs-border-radius-default)` |
|  |  |
| `--fs-select-bkg` | `transparent` |
| `--fs-select-bkg-color-focus` | `var(--fs-color-primary-bkg-light)` |
| `--fs-select-bkg-color-hover` | `var(--fs-select-bkg-color-focus)` |
|  |  |
| `--fs-select-transition-timing` | `var(--fs-transition-timing)` |
| `--fs-select-transition-property` | `var(--fs-transition-property)` |
| `--fs-select-transition-function` | `var(--fs-transition-function)` |
|  |  |
| `--fs-select-label-margin-right` | `var(--fs-spacing-1)` |
| `--fs-select-label-color` | `var(--fs-color-text-light)` |
|  |  |
| `--fs-select-icon-right` | `var(--fs-spacing-2)` |
| `--fs-select-icon-color` | `var(--fs-color-link)` |
|  |  |
| **Disabled:** | ----------------------------------- |
| `--fs-select-disabled-color` | `var(--fs-color-disabled-text)` |
| `--fs-select-disabled-opacity` | `1` |

## How to test it?

The `Select` component should look just as it was before these changes.

Right now, we have an error on Storybook that displays `Select` icon with the wrong style because it needs to have a wrapper to limit the input container. So it will be done in another bug task.

![Screen Shot 2022-05-02 at 18 03 16](https://user-images.githubusercontent.com/15722605/166327649-53297e0f-2132-4aa4-9a9a-7f3fc8195b5a.png)

## Checklist

- [x] Added an entry in the `CHANGELOG.md` at the beginning of its due section. [The latest version should come first](https://keepachangelog.com/en/1.0.0/#:~:text=The%20latest%20version%20comes%20first.).
- [x] Added the PR number with the PR link at the entry in the `CHANGELOG.md`. E.g., *New items in the `pull_request_template.md` ([#12](https://github.com/vtex-sites/gatsby.store/pull/12))* 

- PR description
- [x] Updated the Storybook - *if applicable*.
- [x] Added a label according to the PR goal - `Breaking change`, `Enhancement`, `Bug` or `Chore`.
- [x] Added the component, hook, or pathname in-between backticks (``) *- If applicable*. E.g., *`ComponentName` component*.
