### PR TITLE
feat: Adds new tokens to Link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Applies new local tokens to `Link` ([#19](https://github.com/vtex-sites/gatsby.store/pull/19))
 - ImageGallery to PDP ([#6](https://github.com/vtex-sites/gatsby.store/pull/6))
 - New items in the `pull_request_template.md` ([#12](https://github.com/vtex-sites/gatsby.store/pull/12))
 - Integrates with search.query event api (#2)

--- a/src/components/ui/Link/Link.stories.tsx
+++ b/src/components/ui/Link/Link.stories.tsx
@@ -1,0 +1,32 @@
+import type { LinkProps } from '.'
+import Link from '.'
+
+export default {
+  component: Link,
+  title: 'Atoms/Link',
+  argTypes: {
+    to: {
+      type: { name: 'string', required: true },
+    },
+    ref: {
+      table: {
+        disable: true,
+      },
+    },
+    as: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+}
+
+const Template = ({ ...args }: LinkProps) => <Link {...args}>Link</Link>
+
+export const Default = Template.bind({})
+
+Default.args = {
+  to: '#',
+  variant: 'default',
+  inverse: false,
+}

--- a/src/components/ui/Link/Link.stories.tsx
+++ b/src/components/ui/Link/Link.stories.tsx
@@ -18,10 +18,23 @@ export default {
         disable: true,
       },
     },
+    inverse: {
+      control: 'boolean',
+      table: { defaultValue: false },
+    },
   },
 }
 
-const Template = ({ ...args }: LinkProps) => <Link {...args}>Link</Link>
+const Template = ({ inverse, ...args }: LinkProps) =>
+  inverse ? (
+    <div style={{ backgroundColor: '#171a1c', padding: '10px' }}>
+      <Link inverse {...args}>
+        Link Inverse
+      </Link>
+    </div>
+  ) : (
+    <Link {...args}>Link</Link>
+  )
 
 export const Default = Template.bind({})
 

--- a/src/components/ui/Link/Link.stories.tsx
+++ b/src/components/ui/Link/Link.stories.tsx
@@ -30,3 +30,27 @@ Default.args = {
   variant: 'default',
   inverse: false,
 }
+
+export const Display = Template.bind({})
+
+Display.args = {
+  to: '#',
+  variant: 'display',
+  inverse: false,
+}
+
+export const Footer = Template.bind({})
+
+Footer.args = {
+  to: '#',
+  variant: 'footer',
+  inverse: false,
+}
+
+export const Inline = Template.bind({})
+
+Inline.args = {
+  to: '#',
+  variant: 'inline',
+  inverse: false,
+}

--- a/src/components/ui/Link/Link.tsx
+++ b/src/components/ui/Link/Link.tsx
@@ -1,21 +1,22 @@
 import { Link as UILink } from '@faststore/ui'
 import { Link as GatsbyLink } from 'gatsby'
 import type { ElementType } from 'react'
-import type { LinkProps } from '@faststore/ui'
+import type { LinkProps as UILinkProps } from '@faststore/ui'
 
 type Variant = 'default' | 'display' | 'inline' | 'footer'
 
-type Props<T extends ElementType = typeof GatsbyLink> = LinkProps<T> & {
-  variant?: Variant
-  inverse?: boolean
-}
+export type LinkProps<T extends ElementType = typeof GatsbyLink> =
+  UILinkProps<T> & {
+    variant?: Variant
+    inverse?: boolean
+  }
 
 function Link<T extends ElementType = typeof GatsbyLink>({
   variant = 'default',
   inverse,
   to,
-  ...props
-}: Props<T>) {
+  ...otherProps
+}: LinkProps<T>) {
   return (
     <UILink
       as={GatsbyLink}
@@ -23,7 +24,7 @@ function Link<T extends ElementType = typeof GatsbyLink>({
       data-fs-link-variant={variant}
       data-fs-link-inverse={inverse}
       to={to}
-      {...props}
+      {...otherProps}
     />
   )
 }

--- a/src/components/ui/Link/Link.tsx
+++ b/src/components/ui/Link/Link.tsx
@@ -3,7 +3,7 @@ import { Link as GatsbyLink } from 'gatsby'
 import type { ElementType } from 'react'
 import type { LinkProps as UILinkProps } from '@faststore/ui'
 
-type Variant = 'default' | 'display' | 'inline' | 'footer'
+type Variant = 'default' | 'display' | 'footer' | 'inline'
 
 export type LinkProps<T extends ElementType = typeof GatsbyLink> =
   UILinkProps<T> & {

--- a/src/components/ui/Link/index.ts
+++ b/src/components/ui/Link/index.ts
@@ -1,0 +1,2 @@
+export { default } from './Link'
+export type { LinkProps } from './Link'

--- a/src/components/ui/Link/index.tsx
+++ b/src/components/ui/Link/index.tsx
@@ -1,1 +1,0 @@
-export { default } from './Link'

--- a/src/components/ui/Link/link.scss
+++ b/src/components/ui/Link/link.scss
@@ -12,9 +12,9 @@
 
   --fs-link-border-radius              : var(--fs-border-radius-default);
 
+  --fs-link-text-line-height           : 1.5;
   --fs-link-text-color                 : var(--fs-color-link);
   --fs-link-text-color-visited         : var(--fs-color-link-visited);
-  --fs-link-text-line-height           : 1.5;
   --fs-link-text-decoration            : none;
   --fs-link-text-decoration-hover      : underline;
 

--- a/src/components/ui/Link/link.scss
+++ b/src/components/ui/Link/link.scss
@@ -13,10 +13,10 @@
   --fs-link-border-radius              : var(--fs-border-radius-default);
 
   --fs-link-text-color                 : var(--fs-color-link);
+  --fs-link-text-color-visited         : var(--fs-color-link-visited);
   --fs-link-text-line-height           : 1.5;
   --fs-link-text-decoration            : none;
   --fs-link-text-decoration-hover      : underline;
-  --fs-link-text-color-visited         : var(--fs-color-link-visited);
 
   --fs-link-transition-function        : var(--fs-transition-function);
   --fs-link-transition-property        : var(--fs-transition-property);
@@ -26,7 +26,7 @@
   --fs-link-inverse-text-color-visited : var(--fs-link-inverse-text-color);
 
   // Display
-  --fs-link-display-text-line-height   : 1.5;
+  --fs-link-display-text-line-height   : var(--fs-link-text-line-height);
   --fs-link-display-text-color         : var(--fs-color-text-display);
   --fs-link-display-text-color-visited : var(--fs-link-display-text-color);
 
@@ -35,7 +35,7 @@
   --fs-link-inline-text-decoration     : underline;
 
   // Footer
-  --fs-link-footer-font-size           : var(--fs-text-size-1);
+  --fs-link-footer-text-size           : var(--fs-text-size-1);
   --fs-link-footer-text-color          : var(--fs-color-info-text);
   --fs-link-footer-padding             : var(--fs-spacing-1) var(--fs-spacing-0);
 
@@ -83,7 +83,7 @@ a, [data-fs-link] {
 }
 
 [data-fs-link-variant="footer"] {
-  font-size: var(--fs-link-footer-font-size);
+  font-size: var(--fs-link-footer-text-size);
   color: var(--fs-link-footer-text-color);
 
   @include media(">=notebook") { padding: var(--fs-link-footer-padding); }

--- a/src/components/ui/Link/link.scss
+++ b/src/components/ui/Link/link.scss
@@ -1,48 +1,91 @@
 @import "src/styles/scaffold";
 
+[data-fs-link] {
+  // --------------------------------------------------------
+  // Design Tokens for Link
+  // --------------------------------------------------------
+
+  // Default properties
+  --fs-link-min-width                  : auto;
+  --fs-link-min-height                 : var(--fs-link-min-width);
+  --fs-link-padding                    : var(--fs-spacing-2) var(--fs-spacing-0);
+  --fs-link-text-color                 : var(--fs-color-link);
+  --fs-link-text-line-height           : 1.5;
+  --fs-link-text-decoration            : none;
+  --fs-link-text-decoration-hover      : underline;
+  --fs-link-visited-text-color         : var(--fs-color-link-visited);
+  --fs-link-border-radius              : var(--fs-border-radius-default);
+  --fs-link-box-shadow-transition      : box-shadow .5s ease;
+
+  --fs-link-inverse-text-color         : var(--fs-color-link-inverse);
+  --fs-link-inverse-visited-text-color : var(--fs-link-inverse-text-color);
+
+  // Display
+  --fs-link-display-text-line-height   : 1.5;
+  --fs-link-display-text-color         : var(--fs-color-text-display);
+  --fs-link-display-visited-text-color : var(--fs-link-display-text-color);
+
+  // Inline
+  --fs-link-inline-padding             : 0;
+  --fs-link-inline-text-decoration     : underline;
+
+  // Footer
+  --fs-link-footer-font-size           : var(--fs-text-size-1);
+  --fs-link-footer-text-color          : var(--fs-color-info-text);
+  --fs-link-footer-padding             : var(--fs-spacing-1) var(--fs-spacing-0);
+
+  // --------------------------------------------------------
+  // Structural Styles
+  // --------------------------------------------------------
+
+  min-width: var(--fs-link-min-width);
+  min-height: var(--fs-link-min-height);
+  padding: var(--fs-link-padding);
+  text-decoration: var(--fs-link-text-decoration);
+
+  &:hover { text-decoration: var(--fs-link-text-decoration-hover); }
+
+  &:visited { color: var(--fs-link-visited-text-color); }
+}
+
 a, [data-fs-link] {
-  border-radius: var(--fs-border-radius-default);
-  transition: box-shadow .5s ease;
+  border-radius: var(--fs-link-border-radius);
+  transition: var(--fs-link-box-shadow-transition);
 
   @include focus-ring-visible;
 }
 
-[data-fs-link] {
-  min-width: auto;
-  min-height: auto;
-  padding: var(--fs-spacing-2) var(--fs-spacing-0);
-  text-decoration: none;
-  &:hover { text-decoration: underline; }
-  &:visited { color: var(--fs-color-link-visited); }
+[data-fs-link-inverse="true"] {
+  color: var(--fs-link-inverse-text-color);
+
+  &:visited { color: var(--fs-link-inverse-visited-text-color); }
 }
 
-// Links ////////////////////////////
+// --------------------------------------------------------
+// Variants Styles
+// --------------------------------------------------------
 
 [data-fs-link-variant="default"] {
-  line-height: 1.5;
-  color: var(--fs-color-link);
+  line-height: var(--fs-link-text-line-height);
+  color: var(--fs-link-text-color);
 }
 
 [data-fs-link-variant="display"] {
-  line-height: 1.5;
-  color: var(--fs-color-text-display);
-  &:visited { color: var(--fs-color-text-display); }
+  line-height: var(--fs-link-display-text-line-height);
+  color: var(--fs-link-display-text-color);
+
+  &:visited { color: var(--fs-link-display-visited-text-color); }
 }
 
 [data-fs-link-variant="inline"] {
   display: inline-block;
-  padding: 0;
-  text-decoration: underline;
+  padding: var(--fs-link-inline-padding);
+  text-decoration: var(--fs-link-inline-text-decoration);
 }
 
 [data-fs-link-variant="footer"] {
-  font-size: var(--fs-text-size-1);
-  color: var(--fs-color-text);
+  font-size: var(--fs-link-footer-font-size);
+  color: var(--fs-link-footer-text-color);
 
-  @include media(">=notebook") { padding: var(--fs-spacing-1) var(--fs-spacing-0); }
-}
-
-[data-fs-link-inverse] {
-  color: var(--fs-color-link-inverse);
-  &:visited { color: var(--fs-color-link-inverse); }
+  @include media(">=notebook") { padding: var(--fs-link-footer-padding); }
 }

--- a/src/components/ui/Link/link.scss
+++ b/src/components/ui/Link/link.scss
@@ -9,21 +9,26 @@
   --fs-link-min-width                  : auto;
   --fs-link-min-height                 : var(--fs-link-min-width);
   --fs-link-padding                    : var(--fs-spacing-2) var(--fs-spacing-0);
+
+  --fs-link-border-radius              : var(--fs-border-radius-default);
+
   --fs-link-text-color                 : var(--fs-color-link);
   --fs-link-text-line-height           : 1.5;
   --fs-link-text-decoration            : none;
   --fs-link-text-decoration-hover      : underline;
-  --fs-link-visited-text-color         : var(--fs-color-link-visited);
-  --fs-link-border-radius              : var(--fs-border-radius-default);
-  --fs-link-box-shadow-transition      : box-shadow .5s ease;
+  --fs-link-text-color-visited         : var(--fs-color-link-visited);
+
+  --fs-link-transition-function        : var(--fs-transition-function);
+  --fs-link-transition-property        : var(--fs-transition-property);
+  --fs-link-transition-timing          : var(--fs-transition-timing);
 
   --fs-link-inverse-text-color         : var(--fs-color-link-inverse);
-  --fs-link-inverse-visited-text-color : var(--fs-link-inverse-text-color);
+  --fs-link-inverse-text-color-visited : var(--fs-link-inverse-text-color);
 
   // Display
   --fs-link-display-text-line-height   : 1.5;
   --fs-link-display-text-color         : var(--fs-color-text-display);
-  --fs-link-display-visited-text-color : var(--fs-link-display-text-color);
+  --fs-link-display-text-color-visited : var(--fs-link-display-text-color);
 
   // Inline
   --fs-link-inline-padding             : 0;
@@ -45,20 +50,14 @@
 
   &:hover { text-decoration: var(--fs-link-text-decoration-hover); }
 
-  &:visited { color: var(--fs-link-visited-text-color); }
+  &:visited { color: var(--fs-link-text-color-visited); }
 }
 
 a, [data-fs-link] {
   border-radius: var(--fs-link-border-radius);
-  transition: var(--fs-link-box-shadow-transition);
+  transition: var(--fs-link-transition-property) var(--fs-link-transition-timing) var(--fs-link-transition-function);
 
   @include focus-ring-visible;
-}
-
-[data-fs-link-inverse="true"] {
-  color: var(--fs-link-inverse-text-color);
-
-  &:visited { color: var(--fs-link-inverse-visited-text-color); }
 }
 
 // --------------------------------------------------------
@@ -74,7 +73,7 @@ a, [data-fs-link] {
   line-height: var(--fs-link-display-text-line-height);
   color: var(--fs-link-display-text-color);
 
-  &:visited { color: var(--fs-link-display-visited-text-color); }
+  &:visited { color: var(--fs-link-display-text-color-visited); }
 }
 
 [data-fs-link-variant="inline"] {
@@ -88,4 +87,10 @@ a, [data-fs-link] {
   color: var(--fs-link-footer-text-color);
 
   @include media(">=notebook") { padding: var(--fs-link-footer-padding); }
+}
+
+[data-fs-link-inverse="true"] {
+  color: var(--fs-link-inverse-text-color);
+
+  &:visited { color: var(--fs-link-inverse-text-color-visited); }
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to add new tokens to the `Link` component using the [Theming Structure](https://github.com/vtex-sites/base.store/pull/407).

## How does it work?

This PR uses local variables to parameterize the `Link` properties, then connects these scoped tokens to the global ones.

### New global tokens:
None.

### New local tokens for `Link`:

#### Default properties:
| Local token | Default value/Global token linked |
| - | - | 
| `--fs-link-min-width` | `auto` |
| `--fs-link-min-height` | `var(--fs-link-min-width)` |
| `--fs-link-padding` | `var(--fs-spacing-2) var(--fs-spacing-0)` |
| `--fs-link-text-color` | `var(--fs-color-link)` |
| `--fs-link-text-line-height` | `1.5` |
| `--fs-link-text-decoration` | `none` |
| `--fs-link-text-decoration-hover` | `underline` |
| `--fs-link-visited-text-color` | `var(--fs-color-link-visited)` |
| `--fs-link-border-radius` | `var(--fs-border-radius-default)` |
| `--fs-link-box-shadow-transition` | `box-shadow .5s ease` |
|  |  |
| `--fs-link-inverse-text-color` | `var(--fs-color-link-inverse)` |
| `--fs-link-inverse-visited-text-color` | `var(--fs-link-inverse-text-color)` |

#### Display:
| Local token | Default value/Global token linked |
| - | - | 
| `--fs-link-display-text-line-height` | `1.5` |
| `--fs-link-display-text-color` | `var(--fs-color-text-display)` |
| `--fs-link-display-visited-text-color` | `var(--fs-link-display-text-color)` |

#### Inline
| Local token | Default value/Global token linked |
| - | - | 
| `--fs-link-inline-padding` | `0` |
| `--fs-link-inline-text-decoration` | `underline` |

#### Footer
| Local token | Default value/Global token linked |
| - | - | 
| `--fs-link-footer-font-size` | `var(--fs-text-size-1)` |
| `--fs-link-footer-text-color` | `var(--fs-color-info-text)` |
| `--fs-link-footer-padding` | `var(--fs-spacing-1) var(--fs-spacing-0)` |

## How to test it?

The `Link` component and its variants should look just as it was before these changes.

## Checklist

- [x] Added an entry in the `CHANGELOG.md` at the beginning of its due section. [The latest version should come first](https://keepachangelog.com/en/1.0.0/#:~:text=The%20latest%20version%20comes%20first.).
- [x] Added the PR number with the PR link at the entry in the `CHANGELOG.md`. E.g., *New items in the `pull_request_template.md` ([#12](https://github.com/vtex-sites/gatsby.store/pull/12))* 

- PR description
- [x] Updated the Storybook - *if applicable*.
- [x] Added a label according to the PR goal - `Breaking change`, `Enhancement`, `Bug` or `Chore`.
- [x] Added the component, hook, or pathname in-between backticks (``) *- If applicable*. E.g., *`ComponentName` component*.
