### PR TITLE
fix: Fix missing styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A bugged vertical gap with the `EmptyState` component inside the cart ([#20](https://github.com/vtex-sites/gatsby.store/pull/20)).
 - Some pages missing component styles because they weren't imported ([#20](https://github.com/vtex-sites/gatsby.store/pull/20)).
 - Fix Storybook initialization (#492)
 - Fix styling issue on Regionalization Modal by adding the missing imports in layout.scss (#488)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Some pages missing component styles because they weren't imported ([#20](https://github.com/vtex-sites/gatsby.store/pull/20)).
 - Fix Storybook initialization (#492)
 - Fix styling issue on Regionalization Modal by adding the missing imports in layout.scss (#488)
 - Fix unused CSS problem by separating imports into different files for each page (#473)

--- a/cypress/integration/cart.test.js
+++ b/cypress/integration/cart.test.js
@@ -34,7 +34,7 @@ describe('Cart Sidebar', () => {
       cy.getById('cart-sidebar').should('exist')
 
       // simulate touch scroll. Do not use window.scrollTo
-      cy.get('.empty-state')
+      cy.get('[data-fs-empty-state]')
         .trigger('touchstart', 0, 50)
         .trigger('touchmove', 0, 150)
         .trigger('touchend', 0, 150)

--- a/src/components/sections/ProductGallery/product-gallery.scss
+++ b/src/components/sections/ProductGallery/product-gallery.scss
@@ -6,8 +6,16 @@
   height: 100%;
   padding-top: 0;
 
+  [data-fs-empty-state] {
+    margin: var(--fs-spacing-3) 0;
+  }
+
   @include media(">=notebook") {
     padding-top: var(--fs-spacing-5);
+
+    [data-fs-empty-state] {
+      margin: var(--fs-spacing-5) 0;
+    }
   }
 }
 

--- a/src/components/ui/EmptyState/EmptyState.tsx
+++ b/src/components/ui/EmptyState/EmptyState.tsx
@@ -2,7 +2,7 @@ import type { PropsWithChildren } from 'react'
 
 function EmptyState({ children }: PropsWithChildren<unknown>) {
   return (
-    <section className="empty-state" data-empty-state>
+    <section className="empty-state" data-fs-empty-state>
       {children}
     </section>
   )

--- a/src/components/ui/EmptyState/EmptyState.tsx
+++ b/src/components/ui/EmptyState/EmptyState.tsx
@@ -1,11 +1,7 @@
 import type { PropsWithChildren } from 'react'
 
 function EmptyState({ children }: PropsWithChildren<unknown>) {
-  return (
-    <section className="empty-state" data-fs-empty-state>
-      {children}
-    </section>
-  )
+  return <section data-fs-empty-state>{children}</section>
 }
 
 export default EmptyState

--- a/src/components/ui/EmptyState/empty-state.scss
+++ b/src/components/ui/EmptyState/empty-state.scss
@@ -1,6 +1,6 @@
 @import "src/styles/scaffold";
 
-.empty-state[data-empty-state] {
+.empty-state[data-fs-empty-state] {
   display: flex;
   flex-direction: column;
   row-gap: var(--fs-spacing-3);

--- a/src/components/ui/EmptyState/empty-state.scss
+++ b/src/components/ui/EmptyState/empty-state.scss
@@ -8,13 +8,11 @@
   height: 100%;
   min-height: 50vh;
   padding: 0 var(--fs-spacing-8);
-  margin: var(--fs-spacing-3) 0;
   background-color: var(--fs-color-neutral-bkg);
   border-radius: var(--fs-border-radius-default);
 
   @include media(">=notebook") {
     align-items: center;
-    margin: var(--fs-spacing-5) 0;
   }
 
   > header {

--- a/src/components/ui/EmptyState/empty-state.scss
+++ b/src/components/ui/EmptyState/empty-state.scss
@@ -1,6 +1,6 @@
 @import "src/styles/scaffold";
 
-.empty-state[data-fs-empty-state] {
+[data-fs-empty-state] {
   display: flex;
   flex-direction: column;
   row-gap: var(--fs-spacing-3);

--- a/src/styles/pages/homepage.scss
+++ b/src/styles/pages/homepage.scss
@@ -13,6 +13,5 @@
 @import "src/components/skeletons/SkeletonElement/skeleton-element.scss";
 
 // UI
-@import "src/components/ui/EmptyState/empty-state.scss";
 @import "src/components/ui/Hero/hero.scss";
 @import "src/components/ui/Tiles/tiles.scss";

--- a/src/styles/pages/homepage.scss
+++ b/src/styles/pages/homepage.scss
@@ -13,7 +13,6 @@
 @import "src/components/skeletons/SkeletonElement/skeleton-element.scss";
 
 // UI
-@import "src/components/ui/Badge/badge.scss";
 @import "src/components/ui/EmptyState/empty-state.scss";
 @import "src/components/ui/Hero/hero.scss";
 @import "src/components/ui/Image/image.scss";

--- a/src/styles/pages/homepage.scss
+++ b/src/styles/pages/homepage.scss
@@ -15,6 +15,4 @@
 // UI
 @import "src/components/ui/EmptyState/empty-state.scss";
 @import "src/components/ui/Hero/hero.scss";
-@import "src/components/ui/Image/image.scss";
-@import "src/components/ui/Price/price.scss";
 @import "src/components/ui/Tiles/tiles.scss";

--- a/src/styles/pages/layout.scss
+++ b/src/styles/pages/layout.scss
@@ -23,6 +23,8 @@
 @import "src/components/ui/Alert/alert.scss";
 @import "src/components/ui/Badge/badge.scss";
 @import "src/components/ui/Button/button.scss";
+@import "src/components/ui/Image/image.scss";
 @import "src/components/ui/Link/link.scss";
+@import "src/components/ui/Price/price.scss";
 @import "src/components/ui/SlideOver/slide-over.scss";
 @import "src/components/ui/SROnly/sr-only.scss";

--- a/src/styles/pages/layout.scss
+++ b/src/styles/pages/layout.scss
@@ -21,6 +21,7 @@
 // UI
 @import "src/components/ui/Accordion/accordion.scss";
 @import "src/components/ui/Alert/alert.scss";
+@import "src/components/ui/Badge/badge.scss";
 @import "src/components/ui/Button/button.scss";
 @import "src/components/ui/Link/link.scss";
 @import "src/components/ui/SlideOver/slide-over.scss";

--- a/src/styles/pages/layout.scss
+++ b/src/styles/pages/layout.scss
@@ -23,6 +23,7 @@
 @import "src/components/ui/Alert/alert.scss";
 @import "src/components/ui/Badge/badge.scss";
 @import "src/components/ui/Button/button.scss";
+@import "src/components/ui/EmptyState/empty-state.scss";
 @import "src/components/ui/Image/image.scss";
 @import "src/components/ui/Link/link.scss";
 @import "src/components/ui/Price/price.scss";

--- a/src/styles/pages/pdp.scss
+++ b/src/styles/pages/pdp.scss
@@ -14,9 +14,7 @@
 
 // UI
 @import "src/components/ui/Breadcrumb/breadcrumb.scss";
-@import "src/components/ui/Image/image.scss";
 @import "src/components/ui/ImageGallery/image-gallery.scss";
 @import "src/components/ui/ImageGallery/image-gallery-selector.scss";
-@import "src/components/ui/Price/price.scss";
 @import "src/components/ui/ProductTitle/product-title.scss";
 @import "src/components/ui/QuantitySelector/quantity-selector.scss";

--- a/src/styles/pages/plp.scss
+++ b/src/styles/pages/plp.scss
@@ -2,12 +2,6 @@
 @import "src/components/product/ProductCard/product-card.scss";
 @import "src/components/product/ProductGrid/product-grid.scss";
 
-// Regionalization
-@import "src/components/regionalization/RegionalizationBar/regionalization-bar.scss";
-@import "src/components/regionalization/RegionalizationButton/regionalization-button.scss";
-@import "src/components/regionalization/RegionalizationInput/regionalization-input.scss";
-@import "src/components/regionalization/RegionalizationModal/regionalization-modal.scss";
-
 // Search
 @import "src/components/search/Filter/filter.scss";
 

--- a/src/styles/pages/plp.scss
+++ b/src/styles/pages/plp.scss
@@ -21,7 +21,6 @@
 // UI
 @import "src/components/ui/Breadcrumb/breadcrumb.scss";
 @import "src/components/ui/Checkbox/checkbox.scss";
-@import "src/components/ui/EmptyState/empty-state.scss";
 @import "src/components/ui/Hero/hero.scss";
 @import "src/components/ui/ProductTitle/product-title.scss";
 @import "src/components/ui/Select/select.scss";

--- a/src/styles/pages/plp.scss
+++ b/src/styles/pages/plp.scss
@@ -25,7 +25,6 @@
 @import "src/components/skeletons/SkeletonElement/skeleton-element.scss";
 
 // UI
-@import "src/components/ui/Badge/badge.scss";
 @import "src/components/ui/Breadcrumb/breadcrumb.scss";
 @import "src/components/ui/Checkbox/checkbox.scss";
 @import "src/components/ui/EmptyState/empty-state.scss";

--- a/src/styles/pages/plp.scss
+++ b/src/styles/pages/plp.scss
@@ -29,8 +29,6 @@
 @import "src/components/ui/Checkbox/checkbox.scss";
 @import "src/components/ui/EmptyState/empty-state.scss";
 @import "src/components/ui/Hero/hero.scss";
-@import "src/components/ui/Image/image.scss";
-@import "src/components/ui/Price/price.scss";
 @import "src/components/ui/ProductTitle/product-title.scss";
 @import "src/components/ui/Select/select.scss";
 @import "src/components/ui/Tiles/tiles.scss";

--- a/src/styles/pages/search.scss
+++ b/src/styles/pages/search.scss
@@ -8,9 +8,17 @@
 // Sections
 @import "src/components/sections/Breadcrumb/breadcrumb.scss";
 @import "src/components/sections/ProductGallery/product-gallery.scss";
+@import "src/components/sections/Section/section.scss";
 
 // Skeletons
 @import "src/components/skeletons/FilterSkeleton/filter-skeleton.scss";
 @import "src/components/skeletons/ProductCardSkeleton/product-card-skeleton.scss";
 @import "src/components/skeletons/Shimmer/shimmer.scss";
 @import "src/components/skeletons/SkeletonElement/skeleton-element.scss";
+
+// UI
+@import "src/components/ui/Breadcrumb/breadcrumb.scss";
+@import "src/components/ui/Checkbox/checkbox.scss";
+@import "src/components/ui/Image/image.scss";
+@import "src/components/ui/Price/price.scss";
+@import "src/components/ui/Select/select.scss";

--- a/src/styles/pages/search.scss
+++ b/src/styles/pages/search.scss
@@ -19,6 +19,4 @@
 // UI
 @import "src/components/ui/Breadcrumb/breadcrumb.scss";
 @import "src/components/ui/Checkbox/checkbox.scss";
-@import "src/components/ui/Image/image.scss";
-@import "src/components/ui/Price/price.scss";
 @import "src/components/ui/Select/select.scss";


### PR DESCRIPTION
## What's the purpose of this pull request?

Noticed when I visited some pages using their direct URL (not starting from Home and navigating to other pages -- this triggers the loading of missing CSS), the styles for some components were missing. This is due to the split we made in https://github.com/vtex-sites/base.store/pull/480, except we missed some cases.

## How does it work?

Before|After
-|-
![PDP-1](https://user-images.githubusercontent.com/381395/166262551-58016d50-af4c-43c5-b8da-85d773d3c587.png)|![PDP-2](https://user-images.githubusercontent.com/381395/166262570-890006a4-086d-4c27-93f5-7315eed84177.png)
![PDP-2-1](https://user-images.githubusercontent.com/381395/166262712-253f5f79-3f3e-4b32-b441-5ff32643257e.png)|![PDP-2-2](https://user-images.githubusercontent.com/381395/166262720-05b45704-0718-466f-982a-ac5f9cac23e0.png)
![Search-1](https://user-images.githubusercontent.com/381395/166264088-f29cf6dd-33ae-4ff9-bf46-9e614b085046.png)|![Search-2](https://user-images.githubusercontent.com/381395/166264099-2d9d4d01-8661-4100-8bfb-972af9c11941.png)
![empty-1](https://user-images.githubusercontent.com/381395/166266773-63034d58-72de-4eaf-a229-edbf031e7eeb.png)|![Screen Shot 2022-05-02 at 15 07 31](https://user-images.githubusercontent.com/381395/166301331-223b849d-35ac-4482-9a64-d9f74d1055e4.png)

## How to test it?

Compare this vs production versions:
- https://preview-20--gatsby.preview.vtex.app/apple-magic-mouse-99988212/p vs https://gatsby.vtex.app/apple-magic-mouse-99988212/p
- https://preview-20--gatsby.preview.vtex.app/s/?q=mouse&category-2=appliances&facets=category-2&sort=score_desc&page=0 vs https://gatsby.vtex.app/s/?q=mouse&category-2=appliances&facets=category-2&sort=score_desc&page=0

## References

- https://github.com/vtex-sites/base.store/pull/480