### PR TITLE
chore: Rename Badge prop 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Renames `Badge` component prop `interactive` to `actionable`([#25](https://github.com/vtex-sites/gatsby.store/pull/25))
 - Update Regionalization input to use the `TextInput` component ([#9](https://github.com/vtex-sites/gatsby.store/pull/9))
 - Update `RegionalizationButton` and `RegionalizationBar` to show the postal code (#8)
 - ImageGallery now uses native scroll instead of useSlider ([#6](https://github.com/vtex-sites/gatsby.store/pull/6))

--- a/src/components/ui/Badge/Badge.stories.tsx
+++ b/src/components/ui/Badge/Badge.stories.tsx
@@ -7,6 +7,9 @@ export default {
   title: 'Molecules/Badge',
   argTypes: {
     onClose: { table: { disable: true } },
+    children: {
+      name: 'label',
+    },
   },
 }
 

--- a/src/components/ui/Badge/Badge.stories.tsx
+++ b/src/components/ui/Badge/Badge.stories.tsx
@@ -8,7 +8,7 @@ export default {
   argTypes: {
     onClose: { table: { disable: true } },
     children: {
-      name: 'label',
+      name: 'content',
     },
   },
 }

--- a/src/components/ui/Badge/Badge.stories.tsx
+++ b/src/components/ui/Badge/Badge.stories.tsx
@@ -15,18 +15,18 @@ const Template = ({ children, ...args }: BadgeProps) => (
 )
 
 export const Default = Template.bind({})
-export const Interactive = Template.bind({})
+export const Actionable = Template.bind({})
 
 Default.args = {
   children: 'New arrival',
   big: false,
-  interactive: false,
+  actionable: false,
   variant: 'info',
 }
 
-Interactive.args = {
+Actionable.args = {
   children: 'New arrival',
   big: true,
-  interactive: true,
+  actionable: true,
   variant: 'info',
 }

--- a/src/components/ui/Badge/Badge.tsx
+++ b/src/components/ui/Badge/Badge.tsx
@@ -5,13 +5,13 @@ import type { ReactNode } from 'react'
 
 export type BadgeVariants = 'info' | 'highlighted' | 'success' | 'neutral'
 
-type InteractiveBadge =
+type ActionableBadge =
   | {
-      interactive: true
+      actionable: true
       onClose?: () => void
     }
   | {
-      interactive?: false
+      actionable?: false
       onClose?: never
     }
 
@@ -20,25 +20,25 @@ type Props = {
   variant?: BadgeVariants
   children: ReactNode
   onClose?: () => void
-  interactive?: boolean
-} & InteractiveBadge
+  actionable?: boolean
+} & ActionableBadge
 
 const Badge = ({
   variant = 'neutral',
   children,
   onClose,
   big = false,
-  interactive = false,
+  actionable = false,
   ...otherProps
 }: Props) => {
   return (
     <UIBadge
       data-fs-badge={big ? 'big' : ''}
       data-fs-badge-variant={variant}
-      data-fs-badge-interactive={interactive}
+      data-fs-badge-actionable={actionable}
       {...otherProps}
     >
-      {interactive && (
+      {actionable && (
         <Button
           data-fs-badge-button="true"
           aria-label="Remove"

--- a/src/components/ui/Badge/badge.scss
+++ b/src/components/ui/Badge/badge.scss
@@ -112,7 +112,7 @@
   }
 }
 
-[data-fs-badge-interactive="true"] {
+[data-fs-badge-actionable="true"] {
   position: relative;
   display: flex;
   align-items: center;


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR renames the `Badge` prop according to the listed on Figma and follows `InputText` pattern https://github.com/vtex-sites/gatsby.store/pull/15.
`interactive` -> `actionable`

Ps: Also renamed `children` to `content` on the stories to be more explicit about that control purpose. 

|Before|After|
|-|-|
![Before - interactive](https://user-images.githubusercontent.com/3356699/166721701-caff74c7-ce27-4913-8252-c66fee88a5a2.png)|![After - actionable](https://user-images.githubusercontent.com/3356699/166839532-5667eb34-4c51-4f6d-ba9d-cd21635ac8b0.png)


## How does it work?

`interactive` prop became `actionable`

## How to test it?

Nothing should change visually on the component, and everything should work fine.

## Checklist

<em>You may erase this after checking them all ;)</em>

- [x] Added an entry in the `CHANGELOG.md` at the beginning of its due section. [The latest version should comes first](https://keepachangelog.com/en/1.0.0/#:~:text=The%20latest%20version%20comes%20first.).
- [x] Added the PR number with the PR link at the entry in the `CHANGELOG.md`. E.g., *New items in the `pull_request_template.md` ([#12](https://github.com/vtex-sites/gatsby.store/pull/12))* 


- PR description
- [x] Updated the Storybook - *if applicable*.
- [x] Added a label according to the PR goal - `Breaking change`, `Enhancement`, `Bug` or `Chore`.
- [x] Added the component, hook, or pathname in-between backticks (``) *- If applicable*. E.g., *`ComponentName` component*.
- [x] Identified the function or parameter in the PR *- If applicable*. E.g., *`useWindowDimensions` hook*.
- [ ] For documentation changes, ping @carolinamenezes or @Mariana-Caetano to review and update the changes.

