### PR TITLE
fix: Toggle arrows at the ImageGallery in accordance to scroll position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix `ImageGallerySelector` arrow toggle according to scroll position ([#27](https://github.com/vtex-sites/gatsby.store/pull/27))
 - Fix hydration mismatch on PLPs at `?page=1` pagination
 - A bugged vertical gap with the `EmptyState` component inside the cart ([#20](https://github.com/vtex-sites/gatsby.store/pull/20)).
 - Some pages missing component styles because they weren't imported ([#20](https://github.com/vtex-sites/gatsby.store/pull/20)).

--- a/src/components/ui/Image/Image.tsx
+++ b/src/components/ui/Image/Image.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react'
+import { forwardRef, memo } from 'react'
 import { Helmet } from 'react-helmet-async'
 
 import { useImage } from './useImage'
@@ -8,29 +8,31 @@ interface Props extends ImageOptions {
   preload?: boolean
 }
 
-function Image({ preload = false, ...otherProps }: Props) {
-  const imgProps = useImage(otherProps)
-  const { src, sizes = '100vw', srcSet } = imgProps
+const Image = forwardRef<HTMLImageElement, Props>(
+  ({ preload = false, ...otherProps }, ref) => {
+    const imgProps = useImage(otherProps)
+    const { src, sizes = '100vw', srcSet } = imgProps
 
-  return (
-    <>
-      {preload && (
-        <Helmet
-          link={[
-            {
-              as: 'image',
-              rel: 'preload',
-              href: src,
-              imagesrcset: srcSet,
-              imagesizes: sizes,
-            } as any,
-          ]}
-        />
-      )}
-      <img data-store-image {...imgProps} alt={imgProps.alt} />
-    </>
-  )
-}
+    return (
+      <>
+        {preload && (
+          <Helmet
+            link={[
+              {
+                as: 'image',
+                rel: 'preload',
+                href: src,
+                imagesrcset: srcSet,
+                imagesizes: sizes,
+              } as any,
+            ]}
+          />
+        )}
+        <img ref={ref} data-store-image {...imgProps} alt={imgProps.alt} />
+      </>
+    )
+  }
+)
 
 Image.displayName = 'Image'
 export default memo(Image)

--- a/src/components/ui/ImageGallery/ImageGallerySelector.tsx
+++ b/src/components/ui/ImageGallery/ImageGallerySelector.tsx
@@ -36,11 +36,11 @@ const hasScroll = (container: HTMLDivElement | null): boolean => {
 function ImageGallerySelector({ images, onSelect, currentImageIdx }: Props) {
   const elementsRef = useRef<HTMLDivElement>(null)
   const { ref: firstImageRef, inView: firstImageInView } = useInView({
-    threshold: 0.5,
+    threshold: 1,
   })
 
   const { ref: lastImageRef, inView: lastImageInView } = useInView({
-    threshold: 0.5,
+    threshold: 1,
   })
 
   return (

--- a/src/components/ui/ImageGallery/ImageGallerySelector.tsx
+++ b/src/components/ui/ImageGallery/ImageGallerySelector.tsx
@@ -2,6 +2,7 @@ import { useRef } from 'react'
 import { Button, IconButton } from '@faststore/ui'
 import Icon from 'src/components/ui/Icon'
 import { Image } from 'src/components/ui/Image'
+import { useInView } from 'react-intersection-observer'
 
 import type { ImageElementData } from './ImageGallery'
 
@@ -34,6 +35,8 @@ const hasScroll = (container: HTMLDivElement | null): boolean => {
 
 function ImageGallerySelector({ images, onSelect, currentImageIdx }: Props) {
   const elementsRef = useRef<HTMLDivElement>(null)
+  const { ref: firstImageRef, inView: firstImageInView } = useInView()
+  const { ref: lastImageRef, inView: lastImageInView } = useInView()
 
   return (
     <section
@@ -41,7 +44,7 @@ function ImageGallerySelector({ images, onSelect, currentImageIdx }: Props) {
       aria-roledescription="carousel"
       aria-label="Product images"
     >
-      {hasScroll(elementsRef.current) && (
+      {hasScroll(elementsRef.current) && !firstImageInView && (
         <IconButton
           aria-label="backward slide image selector"
           icon={<Icon name="ArrowLeft" width={24} height={24} />}
@@ -50,6 +53,14 @@ function ImageGallerySelector({ images, onSelect, currentImageIdx }: Props) {
       )}
       <div data-fs-image-gallery-selector-elements ref={elementsRef}>
         {images.map((image, idx) => {
+          let ref
+
+          if (idx === 0) {
+            ref = firstImageRef
+          } else if (idx === images.length - 1) {
+            ref = lastImageRef
+          }
+
           return (
             <Button
               key={idx}
@@ -62,6 +73,7 @@ function ImageGallerySelector({ images, onSelect, currentImageIdx }: Props) {
               onClick={() => onSelect(idx)}
             >
               <Image
+                ref={ref}
                 src={image.url}
                 alt={image.alternateName}
                 loading={idx === 0 ? 'eager' : 'lazy'}
@@ -73,7 +85,7 @@ function ImageGallerySelector({ images, onSelect, currentImageIdx }: Props) {
           )
         })}
       </div>
-      {hasScroll(elementsRef.current) && (
+      {hasScroll(elementsRef.current) && !lastImageInView && (
         <IconButton
           aria-label="forward slide image selector"
           icon={<Icon name="ArrowLeft" width={24} height={24} />}

--- a/src/components/ui/ImageGallery/ImageGallerySelector.tsx
+++ b/src/components/ui/ImageGallery/ImageGallerySelector.tsx
@@ -35,8 +35,13 @@ const hasScroll = (container: HTMLDivElement | null): boolean => {
 
 function ImageGallerySelector({ images, onSelect, currentImageIdx }: Props) {
   const elementsRef = useRef<HTMLDivElement>(null)
-  const { ref: firstImageRef, inView: firstImageInView } = useInView()
-  const { ref: lastImageRef, inView: lastImageInView } = useInView()
+  const { ref: firstImageRef, inView: firstImageInView } = useInView({
+    threshold: 0.5,
+  })
+
+  const { ref: lastImageRef, inView: lastImageInView } = useInView({
+    threshold: 0.5,
+  })
 
   return (
     <section

--- a/src/components/ui/ImageGallery/image-gallery-selector.scss
+++ b/src/components/ui/ImageGallery/image-gallery-selector.scss
@@ -61,7 +61,7 @@
   [data-fs-image-gallery-selector-elements] {
     display: flex;
     column-gap: var(--fs-spacing-1);
-    padding: var(--fs-spacing-0) var(--fs-spacing-6);
+    padding: var(--fs-spacing-0);
     overflow-x: auto;
     scroll-behavior: smooth;
 
@@ -99,7 +99,7 @@
     @include media(">=notebook") {
       flex-direction: column;
       row-gap: var(--fs-spacing-2);
-      padding: var(--fs-spacing-6) var(--fs-spacing-0);
+      padding: var(--fs-spacing-0);
       overflow-y: hidden;
     }
   }


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR fixes the behavior of the ImageGallery, implementing toggle rules for the arrows that are used to navigate in the image minatures:
- The right/up arrow only shows when the first image is not visible
- The left/down arrow only shows when the last image is not visible

## How does it work?
It uses the `inView` value for the first and last images, added using the `useInView()` hook. 
- If the `inView` for the first image is `true`, then the left (mobile)/up (desktop) arrow is not displayed. It is displayed when `inView` is `false`.
  - _This means that the arrow is hidden when we are at the beginning of the image miniatures list, and displayed when we start navigating towards the end of the images._
- If the `inView` for the last image is `true`, then the right (mobile)/down (desktop) arrow is not displayed. It is displayed when `inView` is `false`.
  - _This means that the arrow is hidden when we are at the end of the image miniatures list, and displayed when we start navigating towards the beginning of the images._ 

Preview GIFs:
| Mobile | Desktop |
|--------|---------|
|![fsss-280-mobile-demo](https://user-images.githubusercontent.com/24229855/167203729-b58f123f-7cb7-4eda-8fad-86ee11854359.gif)|![fsss-280-desktop-demo](https://user-images.githubusercontent.com/24229855/167203754-7aba2c94-9331-4d35-856d-95e3daa667ef.gif)|


## How to test it?
Open a product with many images (it is easier to change the code at `ImageGallery.tsx`, at the `ImageGallerySelector` component - update the `images={images}` to `images={images.concat(images.concat(images))}`.

Repeat these steps for both desktop and mobile:
- Verify that when you open a product, only the left/up arrow is not being displayed
- Click the right/down arrow to start navigating. Verify that both arrows are now being displayed (if not, check if the image miniatures list is big enough for that. If necessary, test with another product)
- Navigate until the end of the images list
- Verify that now only the right/down arrow is not being displayed
- Navigate again towards the beginning of the list, clicking the left/down arrow
- Verify that the behavior repeats consistently

## References
[react-intersection-observer](https://github.com/thebuilder/react-intersection-observer)