### PR TITLE
Updates CHANGELOG to match 22.19.0.beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Addded
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [22.19.0.beta] - 2022-05-06
+
 ### Added
 
 - An initial integration of the search term & product suggestions ([#16](https://github.com/vtex-sites/gatsby.store/pull/16)).
@@ -42,8 +56,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Applies new local tokens to `BannerText` ([#470](https://github.com/vtex-sites/base.store/pull/470))
 - Update the `Incentives` component to handle CMS data ([#474](https://github.com/vtex-sites/base.store/pull/474)).
 
-### Deprecated
-
 ### Removed
 
 - The GitHub Action that was running Lighthouse, as it was frequently failing and WebOps already runs it ([#484](https://github.com/vtex-sites/base.store/pull/484)).
@@ -60,8 +72,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix unused CSS problem by separating imports into different files for each page ([#473](https://github.com/vtex-sites/base.store/pull/473))
 - Potential layout shift on `Hero` section fixed ([#472](https://github.com/vtex-sites/base.store/pull/472))
 - Fix layout section spacings style ([#469](https://github.com/vtex-sites/base.store/pull/469))
-
-### Security
 
 ## [0.2.2] - 2022-04-07
 


### PR DESCRIPTION
This PR just updates the CHANGELOG to match our [latest release](https://github.com/vtex-sites/gatsby.store/releases/tag/v22.19.0.beta)