### PR TITLE
Feat/add analytics to cart item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Uses new WebOps Incremental Static Builds ([#47](https://github.com/vtex-sites/gatsby.store/pull/47))
-### Added
-- `add_to_cart` and `remove_from_cart` analytics events to CartItem.
+- `add_to_cart` and `remove_from_cart` analytics events to `CartItem` ([#43](https://github.com/vtex-sites/gatsby.store/pull/43))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Addded
+### Added
 - Uses new WebOps Incremental Static Builds ([#47](https://github.com/vtex-sites/gatsby.store/pull/47))
+### Added
+- `add_to_cart` and `remove_from_cart` analytics events to CartItem.
 
 ### Changed
 


### PR DESCRIPTION
## What's the purpose of this pull request?

Adds  `add_to_cart` and `remove_from_cart` analytics events to `CartItem`.

## How does it work?

Sends the event whenever the quantity changes, and uses the quantity delta to determine which event to send.

## How to test it?

Browse the website, run the script below on the console, add an item to the cart, and change its quantity using the quantity selector (both by typing and clicking buttons).

You should see the events being logged on the dataLayer.

```js
const oldPush = dataLayer.push
dataLayer.push = (data) => {console.log(data); oldPush(data)}
```

## References

It's important that the quantity fields are filled with the absolute delta value since it implies that only this certain quantity is being added or removed from the cart. 

https://github.com/vtex-sites/nextjs.store/pull/35
## Checklist

<em>You may erase this after checking them all ;)</em>

- [x] Added an entry in the `CHANGELOG.md` at the beginning of its due section. [The latest version should comes first](https://keepachangelog.com/en/1.0.0/#:~:text=The%20latest%20version%20comes%20first.).
- [x] Added the PR number with the PR link at the entry in the `CHANGELOG.md`. E.g., *New items in the `pull_request_template.md` ([#4](https://github.com/vtex-sites/nextjs.store/pull/4))* 


- PR description
- [ ] Updated the Storybook - *if applicable*.
- [x] Added a label according to the PR goal - `Breaking change`, `Enhancement`, `Bug` or `Chore`.
- [x] Added the component, hook, or pathname in-between backticks (``) *- If applicable*. E.g., *`ComponentName` component*.
- [ ] Identified the function or parameter in the PR *- If applicable*. E.g., *`useWindowDimensions` hook*.
- [ ] For documentation changes, ping @carolinamenezes or @Mariana-Caetano to review and update the changes.

