### PR TITLE
feat: Incremental Static Build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Addded
+- Uses new WebOps Incremental Builds ([#47](https://github.com/vtex-sites/gatsby.store/pull/47))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Addded
-- Uses new WebOps Incremental Builds ([#47](https://github.com/vtex-sites/gatsby.store/pull/47))
+- Uses new WebOps Incremental Static Builds ([#47](https://github.com/vtex-sites/gatsby.store/pull/47))
 
 ### Changed
 

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -175,6 +175,8 @@ export const getServerData = async ({
 }: {
   params: Record<string, string>
 }) => {
+  const ONE_YEAR_CACHE = `s-maxage=31536000, stale-while-revalidate`
+
   try {
     const { execute } = await import('src/server/index')
     const { data } = await execute({
@@ -189,7 +191,7 @@ export const getServerData = async ({
         status: 301,
         props: {},
         headers: {
-          'cache-control': 's-maxage=31536000, stale-while-revalidate',
+          'cache-control': ONE_YEAR_CACHE,
           location: `/404/?from=${encodeURIComponent(originalUrl)}`,
         },
       }
@@ -199,7 +201,7 @@ export const getServerData = async ({
       status: 200,
       props: data ?? {},
       headers: {
-        'cache-control': 's-maxage=31536000, stale-while-revalidate',
+        'cache-control': ONE_YEAR_CACHE,
       },
     }
   } catch (err) {

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -189,7 +189,7 @@ export const getServerData = async ({
         status: 301,
         props: {},
         headers: {
-          'cache-control': 'public, max-age=0, stale-while-revalidate=31536000',
+          'cache-control': 's-maxage=31536000, stale-while-revalidate',
           location: `/404/?from=${encodeURIComponent(originalUrl)}`,
         },
       }
@@ -199,7 +199,7 @@ export const getServerData = async ({
       status: 200,
       props: data ?? {},
       headers: {
-        'cache-control': 'public, max-age=0, stale-while-revalidate=31536000',
+        'cache-control': 's-maxage=31536000, stale-while-revalidate',
       },
     }
   } catch (err) {

--- a/src/pages/[slug]/p.tsx
+++ b/src/pages/[slug]/p.tsx
@@ -200,7 +200,7 @@ export const getServerData = async ({
         status: 301,
         props: {},
         headers: {
-          'cache-control': 'public, max-age=0, stale-while-revalidate=31536000',
+          'cache-control': 's-maxage=31536000, stale-while-revalidate',
           location: `/404/?from=${encodeURIComponent(originalUrl)}`,
         },
       }
@@ -210,7 +210,7 @@ export const getServerData = async ({
       status: 200,
       props: data ?? {},
       headers: {
-        'cache-control': 'public, max-age=0, stale-while-revalidate=31536000',
+        'cache-control': 's-maxage=31536000, stale-while-revalidate',
       },
     }
   } catch (err) {

--- a/src/pages/[slug]/p.tsx
+++ b/src/pages/[slug]/p.tsx
@@ -184,6 +184,8 @@ export const getServerData = async ({
 }: {
   params: Record<string, string>
 }) => {
+  const ONE_YEAR_CACHE = `s-maxage=31536000, stale-while-revalidate`
+
   try {
     const id = slug.split('-').pop()
 
@@ -200,7 +202,7 @@ export const getServerData = async ({
         status: 301,
         props: {},
         headers: {
-          'cache-control': 's-maxage=31536000, stale-while-revalidate',
+          'cache-control': ONE_YEAR_CACHE,
           location: `/404/?from=${encodeURIComponent(originalUrl)}`,
         },
       }
@@ -210,7 +212,7 @@ export const getServerData = async ({
       status: 200,
       props: data ?? {},
       headers: {
-        'cache-control': 's-maxage=31536000, stale-while-revalidate',
+        'cache-control': ONE_YEAR_CACHE,
       },
     }
   } catch (err) {

--- a/vtex.env
+++ b/vtex.env
@@ -6,6 +6,7 @@ GATSBY_QUERY_ON_DEMAND_LOADING_INDICATOR=false
 # configures WebOps
 USE_NODE_MODULES_CACHE=true
 USE_FRAMEWORK_CACHE=true
+USE_STALE_CACHE=true
 
 # 🐞🐞 Uncomment for debugging final bundle 🐞🐞
 # GATSBY_STORE_PROFILING=true


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR uses the new WebOps capability called Incremental Static Builds. This should drastically improve response times and reduce infrastructure usage on deferred pages, like PDPs and PLPs

## How does it work?
WebOps recently released this Incremental Static Builds feature. To use on Gatsby, make sure to return the following cache-control headers on SSR pages:
```
'cache-control': 's-maxage=31536000, stale-while-revalidate',
```
and enable `USE_STALE_CACHE=true` on `vtex.env`.

## How to test it?
Open a PDP. Check the response header called `x-faststore-cache`. The first request should give you a `MISS`. The second request should give you `HIT`. Note that `HIT`s are much faster than `MISS`. Also, note that all subsequent requests have a HIT as value. 

## References
- Original PR on WebOps: https://github.com/vtex/vtex-cicd-platform/pull/105
