### PR TITLE
fix: Resolves `@reach/router` on storybook

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -27,6 +27,11 @@ module.exports = {
       }),
     ]
 
+    config.resolve.alias['@reach/router'] = resolve(
+      __dirname,
+      '../node_modules/@gatsbyjs/reach-router'
+    )
+
     return config
   },
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix storybook `@reach/router` issue ([#48](https://github.com/vtex-sites/gatsby.store/pull/48))
+- Fix Storybook `@reach/router` issue ([#48](https://github.com/vtex-sites/gatsby.store/pull/48))
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix storybook `@reach/router` issue ([#48](https://github.com/vtex-sites/gatsby.store/pull/48))
+
 ### Security
 
 ## [22.19.0.beta] - 2022-05-06


### PR DESCRIPTION
## What's the purpose of this pull request?

Previously we removed `@reach/router` from our [package.json](https://github.com/vtex-sites/gatsby.store/pull/42/files) because we are using `@gatsbyjs/reach-router` instead. But we're still using it on the storybook, and it is currently broken. To avoid it, I've added an alias.

![image](https://user-images.githubusercontent.com/3356699/168643190-1f6ca6aa-d819-4871-b61c-6235b8042cc2.png)


Ps: Let's see later if we can handle this situation with another approach.  

## How does it work?

It should fix storybook build.

## How to test it?

The storybook [preview](https://gatsby-store-storybook-git-fix-storybook-router-alias-faststore.vercel.app/?path=/story/releases-changelog--page) should be working fine.

## References

[@gatsbyjs/reach-router](https://www.npmjs.com/package/@gatsbyjs/reach-router)
[webpack.js.org](https://webpack.js.org/configuration/resolve/#resolvealias)
