### PR TITLE
fix: Fixes custom attributes for `img` and `link` tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Limit custom props only for `img` and `link` tags ([#60](https://github.com/vtex-sites/gatsby.store/pull/60))
 - `ArrowsClockwise` icon closing tag ([#57](https://github.com/vtex-sites/gatsby.store/pull/57))
 - Fix Storybook `@reach/router` issue ([#48](https://github.com/vtex-sites/gatsby.store/pull/48))
 

--- a/src/components/sections/Hero/Hero.tsx
+++ b/src/components/sections/Hero/Hero.tsx
@@ -46,7 +46,7 @@ const Hero = ({
           <Image
             preload
             loading="eager"
-            fetchpriority="high"
+            fetchPriority="high"
             src={imageSrc}
             alt={imageAlt}
             width={360}

--- a/src/components/ui/Image/Image.tsx
+++ b/src/components/ui/Image/Image.tsx
@@ -7,7 +7,11 @@ import type { ImageOptions } from './useImage'
 // React still don't have imageSizes declared on its types. Somehow,
 // it generated the right html
 declare module 'react' {
-  interface HTMLAttributes<T> extends AriaAttributes, DOMAttributes<T> {
+  interface ImgHTMLAttributes<T> extends AriaAttributes, DOMAttributes<T> {
+    fetchpriority?: string
+  }
+
+  interface LinkHTMLAttributes<T> extends AriaAttributes, DOMAttributes<T> {
     imageSizes?: string
     fetchpriority?: string
   }
@@ -15,10 +19,11 @@ declare module 'react' {
 
 interface Props extends ImageOptions {
   preload?: boolean
+  fetchPriority?: string
 }
 
 const Image = forwardRef<HTMLImageElement, Props>(
-  ({ preload = false, fetchpriority, ...otherProps }, ref) => {
+  ({ preload = false, fetchPriority, ...otherProps }, ref) => {
     const imgProps = useImage(otherProps)
     const { src, sizes = '100vw', srcSet } = imgProps
 
@@ -33,7 +38,7 @@ const Image = forwardRef<HTMLImageElement, Props>(
                 href: src,
                 imagesrcset: srcSet,
                 imagesizes: sizes,
-                fetchpriority,
+                fetchpriority: fetchPriority,
               } as any,
             ]}
           />
@@ -43,7 +48,7 @@ const Image = forwardRef<HTMLImageElement, Props>(
           data-store-image
           {...imgProps}
           alt={imgProps.alt}
-          fetchpriority={fetchpriority}
+          fetchpriority={fetchPriority}
         />
       </>
     )

--- a/src/components/ui/Image/Image.tsx
+++ b/src/components/ui/Image/Image.tsx
@@ -12,7 +12,7 @@ declare module 'react' {
   }
 
   interface LinkHTMLAttributes<T> extends AriaAttributes, DOMAttributes<T> {
-    imageSizes?: string
+    imagesizes?: string
     fetchpriority?: string
   }
 }
@@ -30,18 +30,16 @@ const Image = forwardRef<HTMLImageElement, Props>(
     return (
       <>
         {preload && (
-          <Helmet
-            link={[
-              {
-                as: 'image',
-                rel: 'preload',
-                href: src,
-                imagesrcset: srcSet,
-                imagesizes: sizes,
-                fetchpriority: fetchPriority,
-              } as any,
-            ]}
-          />
+          <Helmet>
+            <link
+              as="image"
+              rel="preload"
+              href={src}
+              imageSrcSet={srcSet}
+              imagesizes={sizes}
+              fetchpriority={fetchPriority}
+            />
+          </Helmet>
         )}
         <img
           ref={ref}

--- a/src/components/ui/ImageGallery/ImageGallery.tsx
+++ b/src/components/ui/ImageGallery/ImageGallery.tsx
@@ -31,7 +31,7 @@ function ImageGallery({ images }: ImageGalleryProps) {
           width={804}
           height={804 * (3 / 4)}
           loading="eager"
-          fetchpriority="high"
+          fetchPriority="high"
         />
       </ImageZoom>
       {hasSelector && (


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to fix global props being visible/possible for types/interfaces extended from a global interface.

In the `Image` component we declared some props for the React global interface, `HTMLAttributes`, and it affected other components. We could detect this by looking into Storybook args for any component:

![Screen Shot 2022-05-24 at 13 49 32](https://user-images.githubusercontent.com/15722605/170095783-56ff4a83-f145-4f5c-822c-8e0f0bac7c19.png)
![Screen Shot 2022-05-24 at 13 51 35](https://user-images.githubusercontent.com/15722605/170095792-3963ef40-d762-4a71-96e5-fc74edf7bb12.png)

## How does it work?

With these changes, we narrowed the custom attributes only to the specific HTML tags `img` and `link`.

## How to test it?

It can be tested by looking into the components' Storybook args and checking if any of the custom attributes (i.e, `fetchPriority`) are visible.

## Checklist

- [x] Added an entry in the `CHANGELOG.md` at the beginning of its due section. [The latest version should comes first](https://keepachangelog.com/en/1.0.0/#:~:text=The%20latest%20version%20comes%20first.).
- [x] Added the PR number with the PR link at the entry in the `CHANGELOG.md`. E.g., *New items in the `pull_request_template.md` ([#12](https://github.com/vtex-sites/gatsby.store/pull/12))* 

- PR description
- [x] Added a label according to the PR goal - `Breaking change`, `Enhancement`, `Bug` or `Chore`.