### PR TITLE
fix: Fixes <link /> attribute typo

### DIFF
--- a/src/components/ui/Image/Image.tsx
+++ b/src/components/ui/Image/Image.tsx
@@ -12,7 +12,7 @@ declare module 'react' {
   }
 
   interface LinkHTMLAttributes<T> extends AriaAttributes, DOMAttributes<T> {
-    imagesizes?: string
+    imageSizes?: string
     fetchpriority?: string
   }
 }
@@ -36,7 +36,7 @@ const Image = forwardRef<HTMLImageElement, Props>(
               rel="preload"
               href={src}
               imageSrcSet={srcSet}
-              imagesizes={sizes}
+              imageSizes={sizes}
               fetchpriority={fetchPriority}
             />
           </Helmet>


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to fix a `link` attribute typo. (`imageSizes` instead `imagesizes`). For the Gatsby local build, we can't see the log warning.

## How to test it?

Just try to build locally and go to the homepage, the terminal should not show the warning again.