### PR TITLE
chore: Uses CSS Modules on `QuantitySelector`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Uses CSS Modules on `QuantitySelector` component [#75](https://github.com/vtex-sites/gatsby.store/pull/75)
 - `OutOfStock` component ([#70](https://github.com/vtex-sites/nextjs.store/pull/70))
 - Displays 5 products on product suggestion for better mobile experience ([#73](https://github.com/vtex-sites/gatsby.store/pull/73))
 - Uses CSS Modules on `ProductGallery` section [#54](https://github.com/vtex-sites/gatsby.store/pull/54)
@@ -35,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+
 - Search suggestions missing locale info ([#69](https://github.com/vtex-sites/gatsby.store/pull/69))
 - Limit custom props only for `img` and `link` tags ([#60](https://github.com/vtex-sites/gatsby.store/pull/60))
 - `ArrowsClockwise` icon closing tag ([#57](https://github.com/vtex-sites/gatsby.store/pull/57))

--- a/src/components/ui/QuantitySelector/QuantitySelector.tsx
+++ b/src/components/ui/QuantitySelector/QuantitySelector.tsx
@@ -2,6 +2,8 @@ import { QuantitySelector as UIQuantitySelector } from '@faststore/ui'
 import { memo, useEffect, useState } from 'react'
 import Icon from 'src/components/ui/Icon'
 
+import styles from './quantity-selector.module.scss'
+
 interface QuantitySelectorProps {
   max?: number
   min?: number
@@ -59,6 +61,7 @@ export function QuantitySelector({
   return (
     <UIQuantitySelector
       data-fs-quantity-selector={disabled ? 'disabled' : 'true'}
+      className={styles.fsQuantitySelector}
       quantity={quantity}
       leftButtonProps={{
         onClick: decrease,

--- a/src/components/ui/QuantitySelector/quantity-selector.module.scss
+++ b/src/components/ui/QuantitySelector/quantity-selector.module.scss
@@ -1,6 +1,6 @@
 @import "src/styles/scaffold";
 
-[data-fs-quantity-selector] {
+.fs-quantity-selector {
   // --------------------------------------------------------
   // Design Tokens for Quantity Selector
   // --------------------------------------------------------

--- a/src/styles/global/storybook-components.scss
+++ b/src/styles/global/storybook-components.scss
@@ -47,7 +47,6 @@
 @import "src/components/ui/Link/link.scss";
 @import "src/components/ui/Price/price.scss";
 @import "src/components/ui/ProductTitle/product-title.scss";
-@import "src/components/ui/QuantitySelector/quantity-selector.scss";
 @import "src/components/ui/Select/select.scss";
 @import "src/components/ui/SlideOver/slide-over.scss";
 @import "src/components/ui/SROnly/sr-only.scss";

--- a/src/styles/pages/pdp.scss
+++ b/src/styles/pages/pdp.scss
@@ -14,4 +14,3 @@
 // UI
 @import "src/components/ui/Breadcrumb/breadcrumb.scss";
 @import "src/components/ui/ProductTitle/product-title.scss";
-@import "src/components/ui/QuantitySelector/quantity-selector.scss";


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR uses CSS modules to import the QuantitySelector component.

## How does it work?

<em>Tell us the role of the new feature, or component, in its context.</em>

## How to test it?

Check if the `QuantitySelector` works at the cart and at the PDP.

## Checklist

<em>You may erase this after checking them all ;)</em>

- [x] Added an entry in the `CHANGELOG.md` at the beginning of its due section. [The latest version should comes first](https://keepachangelog.com/en/1.0.0/#:~:text=The%20latest%20version%20comes%20first.).
- [x] Added the PR number with the PR link at the entry in the `CHANGELOG.md`. E.g., *New items in the `pull_request_template.md` ([#12](https://github.com/vtex-sites/gatsby.store/pull/12))* 


- PR description
- [x] Updated the Storybook - *if applicable*.
- [x] Added a label according to the PR goal - `Breaking change`, `Enhancement`, `Bug` or `Chore`.
- [x] Added the component, hook, or pathname in-between backticks (``) *- If applicable*. E.g., *`ComponentName` component*.
- [x] Identified the function or parameter in the PR *- If applicable*. E.g., *`useWindowDimensions` hook*.
- [x] For documentation changes, ping @carolinamenezes or @Mariana-Caetano to review and update the changes.

