### PR TITLE
fix: Moves `QuantitySelector` variant attribute inside css class

### DIFF
--- a/src/components/ui/QuantitySelector/quantity-selector.module.scss
+++ b/src/components/ui/QuantitySelector/quantity-selector.module.scss
@@ -145,16 +145,16 @@
       box-shadow: var(--fs-qty-selector-shadow-hover);
     }
   }
-}
 
-// --------------------------------------------------------
-// Variants Styles
-// --------------------------------------------------------
+  // --------------------------------------------------------
+  // Variants Styles
+  // --------------------------------------------------------
 
-[data-fs-quantity-selector="disabled"] {
-  [data-quantity-selector-input] {
-    background-color: var(--fs-qty-selector-disabled-bkg-color);
-    border-color: var(--fs-qty-selector-disabled-border-color);
+  &[data-fs-quantity-selector="disabled"] {
+    [data-quantity-selector-input] {
+      background-color: var(--fs-qty-selector-disabled-bkg-color);
+      border-color: var(--fs-qty-selector-disabled-border-color);
+    }
+    [data-quantity-selector-button]:hover [data-store-icon] { background-color: transparent; }
   }
-  [data-quantity-selector-button]:hover [data-store-icon] { background-color: transparent; }
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

Little reactoring to move the variant `data-attribute` of the `QuantitySelector` inside the main class.

## How to test it?

QuantitySelector should work at cart and PDP

## Checklist

<em>You may erase this after checking them all ;)</em>

I've skiped the Changelog for this one.

- PR description
- [x] Added a label according to the PR goal - `Breaking change`, `Enhancement`, `Bug` or `Chore`.
- [x] Added the component, hook, or pathname in-between backticks (``) *- If applicable*. E.g., *`ComponentName` component*.
- [x] Identified the function or parameter in the PR *- If applicable*. E.g., *`useWindowDimensions` hook*.

