### PR TITLE
Fix: Updates `Toggle` tokens documentation

### DIFF
--- a/.storybook/storybook.css
+++ b/.storybook/storybook.css
@@ -3,7 +3,7 @@
   margin-bottom: var(--fs-spacing-4);
   color: var(--fs-color-text-inverse);
   background-color: var(--fs-color-main-0);
-  border-radius: var(--fs-border-radius-default);
+  border-radius: var(--fs-border-radius);
 }
 
 .sbdocs-content > header h1 { margin-bottom: 0; }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated `Toggle` tokens documentation
+- Updated `Toggle` tokens documentation [#78](https://github.com/vtex-sites/gatsby.store/pull/78)
 - Uses CSS Modules on `QuantitySelector` component [#75](https://github.com/vtex-sites/gatsby.store/pull/75)
 - `OutOfStock` component ([#70](https://github.com/vtex-sites/nextjs.store/pull/70))
 - Displays 5 products on product suggestion for better mobile experience ([#73](https://github.com/vtex-sites/gatsby.store/pull/73))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updated `Toggle` tokens documentation
 - Uses CSS Modules on `QuantitySelector` component [#75](https://github.com/vtex-sites/gatsby.store/pull/75)
 - `OutOfStock` component ([#70](https://github.com/vtex-sites/nextjs.store/pull/70))
 - Displays 5 products on product suggestion for better mobile experience ([#73](https://github.com/vtex-sites/gatsby.store/pull/73))

--- a/src/components/ui/Toggle/Toggle.stories.mdx
+++ b/src/components/ui/Toggle/Toggle.stories.mdx
@@ -88,7 +88,7 @@ An input checkbox styled to look like a switch button.
       </td>
       <td>
         <div style={{ backgroundColor: 'var(--fs-color-main-3)' }} />
-        <code>var(--fs-control-bkg-default)</code>
+        <code>var(--fs-control-bkg)</code>
       </td>
     </tr>
     <tr>
@@ -129,8 +129,8 @@ An input checkbox styled to look like a switch button.
         <code>--fs-toggle-border-color</code>
       </td>
       <td>
-        <div style={{ backgroundColor: 'var(--fs-border-color-default)' }} />
-        <code>var(--fs-border-color-default)</code>
+        <div style={{ backgroundColor: 'var(--fs-border-color)' }} />
+        <code>var(--fs-border-color)</code>
       </td>
     </tr>
     <tr>
@@ -138,10 +138,8 @@ An input checkbox styled to look like a switch button.
         <code>--fs-toggle-border-color-hover</code>
       </td>
       <td>
-        <div
-          style={{ backgroundColor: 'var(--fs-border-color-default-hover)' }}
-        />
-        <code>var(--fs-border-color-default-hover)</code>
+        <div style={{ backgroundColor: 'var(--fs-border-color-hover)' }} />
+        <code>var(--fs-border-color-hover)</code>
       </td>
     </tr>
     <tr>
@@ -149,7 +147,7 @@ An input checkbox styled to look like a switch button.
         <code>--fs-toggle-border-radius</code>
       </td>
       <td>
-        <code>var(--fs-border-radius-default)</code>
+        <code>var(--fs-border-radius)</code>
       </td>
     </tr>
     <tr>
@@ -157,7 +155,7 @@ An input checkbox styled to look like a switch button.
         <code>--fs-toggle-border-width</code>
       </td>
       <td>
-        <code>var(--fs-border-width-default)</code>
+        <code>var(--fs-border-width)</code>
       </td>
     </tr>
     <tr>
@@ -233,9 +231,7 @@ An input checkbox styled to look like a switch button.
         <code>--fs-toggle-knob-bkg-color-hover</code>
       </td>
       <td>
-        <div
-          style={{ backgroundColor: 'var(--fs-border-color-default-hover)' }}
-        />
+        <div style={{ backgroundColor: 'var(--fs-border-color-hover)' }} />
         <code>var(--fs-toggle-border-color-hover)</code>
       </td>
     </tr>
@@ -261,9 +257,7 @@ An input checkbox styled to look like a switch button.
         <code>--fs-toggle-knob-border-color-hover</code>
       </td>
       <td>
-        <div
-          style={{ backgroundColor: 'var(--fs-border-color-default-hover)' }}
-        />
+        <div style={{ backgroundColor: 'var(--fs-border-color-hover)' }} />
         <code>var(--fs-toggle-border-color-hover)</code>
       </td>
     </tr>
@@ -284,8 +278,8 @@ An input checkbox styled to look like a switch button.
         <code>--fs-toggle-knob-checked-bkg-color</code>
       </td>
       <td>
-        <div style={{ backgroundColor: 'var(--fs-control-bkg-default)' }} />
-        <code>var(--fs-control-bkg-default)</code>
+        <div style={{ backgroundColor: 'var(--fs-control-bkg)' }} />
+        <code>var(--fs-control-bkg)</code>
       </td>
     </tr>
     <tr>
@@ -293,7 +287,7 @@ An input checkbox styled to look like a switch button.
         <code>--fs-toggle-knob-checked-border-color</code>
       </td>
       <td>
-        <div style={{ backgroundColor: 'var(--fs-control-bkg-default)' }} />
+        <div style={{ backgroundColor: 'var(--fs-control-bkg)' }} />
         <code>var(--fs-toggle-knob-checked-bkg-color)</code>
       </td>
     </tr>
@@ -475,10 +469,8 @@ An input checkbox styled to look like a switch button.
         <code>fs-toggle-checked-border-color</code>
       </td>
       <td>
-        <div
-          style={{ backgroundColor: 'var(--fs-border-color-default-active' }}
-        />
-        <code>var(--fs-border-color-default-active)</code>
+        <div style={{ backgroundColor: 'var(--fs-border-color-active' }} />
+        <code>var(--fs-border-color-active)</code>
       </td>
     </tr>
     <tr>
@@ -547,10 +539,8 @@ An input checkbox styled to look like a switch button.
         <code>--fs-toggle-disabled-border-color</code>
       </td>
       <td>
-        <div
-          style={{ backgroundColor: 'var(--fs-border-color-default-disabled)' }}
-        />
-        <code>var(--fs-border-color-default-disabled)</code>
+        <div style={{ backgroundColor: 'var(--fs-border-color-disabled)' }} />
+        <code>var(--fs-border-color-disabled)</code>
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
## What's the purpose of this pull request?

On https://github.com/vtex-sites/gatsby.store/pull/28, we decided to remove the `-default` suffix from some of our tokens. This PR updates `Toggle` tokens documentation according.

![image](https://user-images.githubusercontent.com/3356699/171073682-574f883f-91b3-444a-9c47-fe4a4b9d6d31.png)

## How does it work?

Updates `Toggle` tokens documentation, removing `-default` suffix.

## How to test it?

All the tokens listed on the documentation should exist on the stylesheets.

## Checklist

<em>You may erase this after checking them all ;)</em>

- [x] Added an entry in the `CHANGELOG.md` at the beginning of its due section. [The latest version should comes first](https://keepachangelog.com/en/1.0.0/#:~:text=The%20latest%20version%20comes%20first.).
- [x] Added the PR number with the PR link at the entry in the `CHANGELOG.md`. E.g., *New items in the `pull_request_template.md` ([#12](https://github.com/vtex-sites/gatsby.store/pull/12))* 


- PR description
- [x] Updated the Storybook - *if applicable*.
- [x] Added a label according to the PR goal - `Breaking change`, `Enhancement`, `Bug` or `Chore`.
- [x] Added the component, hook, or pathname in-between backticks (``) *- If applicable*. E.g., *`ComponentName` component*.
- [x] Identified the function or parameter in the PR *- If applicable*. E.g., *`useWindowDimensions` hook*.
- [ ] For documentation changes, ping @carolinamenezes or @Mariana-Caetano to review and update the changes.

