### PR TITLE
fix: Removes unused `-default` at css variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Unused `-default` at css variables ([#82](https://github.com/vtex-sites/gatsby.store/pull/82))
+
 ### Fixed
 
 - Search suggestions missing locale info ([#69](https://github.com/vtex-sites/gatsby.store/pull/69))

--- a/src/components/ui/Toggle/Toggle.stories.mdx
+++ b/src/components/ui/Toggle/Toggle.stories.mdx
@@ -139,7 +139,7 @@ An input checkbox styled to look like a switch button.
       </td>
       <td>
         <div style={{ backgroundColor: 'var(--fs-color-main-3)' }} />
-        <code>var(--fs-control-bkg-default)</code>
+        <code>var(--fs-control-bkg)</code>
       </td>
     </tr>
     <tr>
@@ -180,8 +180,8 @@ An input checkbox styled to look like a switch button.
         <code>--fs-toggle-border-color</code>
       </td>
       <td>
-        <div style={{ backgroundColor: 'var(--fs-border-color-default)' }} />
-        <code>var(--fs-border-color-default)</code>
+        <div style={{ backgroundColor: 'var(--fs-border-color)' }} />
+        <code>var(--fs-border-color)</code>
       </td>
     </tr>
     <tr>
@@ -190,9 +190,9 @@ An input checkbox styled to look like a switch button.
       </td>
       <td>
         <div
-          style={{ backgroundColor: 'var(--fs-border-color-default-hover)' }}
+          style={{ backgroundColor: 'var(--fs-border-color-hover)' }}
         />
-        <code>var(--fs-border-color-default-hover)</code>
+        <code>var(--fs-border-color-hover)</code>
       </td>
     </tr>
     <tr>
@@ -200,7 +200,7 @@ An input checkbox styled to look like a switch button.
         <code>--fs-toggle-border-radius</code>
       </td>
       <td>
-        <code>var(--fs-border-radius-default)</code>
+        <code>var(--fs-border-radius)</code>
       </td>
     </tr>
     <tr>
@@ -208,7 +208,7 @@ An input checkbox styled to look like a switch button.
         <code>--fs-toggle-border-width</code>
       </td>
       <td>
-        <code>var(--fs-border-width-default)</code>
+        <code>var(--fs-border-width)</code>
       </td>
     </tr>
     <tr>
@@ -283,7 +283,7 @@ An input checkbox styled to look like a switch button.
       </td>
       <td>
         <div
-          style={{ backgroundColor: 'var(--fs-border-color-default-hover)' }}
+          style={{ backgroundColor: 'var(--fs-border-color-hover)' }}
         />
         <code>var(--fs-toggle-border-color-hover)</code>
       </td>
@@ -311,7 +311,7 @@ An input checkbox styled to look like a switch button.
       </td>
       <td>
         <div
-          style={{ backgroundColor: 'var(--fs-border-color-default-hover)' }}
+          style={{ backgroundColor: 'var(--fs-border-color-hover)' }}
         />
         <code>var(--fs-toggle-border-color-hover)</code>
       </td>
@@ -333,8 +333,8 @@ An input checkbox styled to look like a switch button.
         <code>--fs-toggle-knob-checked-bkg-color</code>
       </td>
       <td>
-        <div style={{ backgroundColor: 'var(--fs-control-bkg-default)' }} />
-        <code>var(--fs-control-bkg-default)</code>
+        <div style={{ backgroundColor: 'var(--fs-control-bkg)' }} />
+        <code>var(--fs-control-bkg)</code>
       </td>
     </tr>
     <tr>
@@ -342,7 +342,7 @@ An input checkbox styled to look like a switch button.
         <code>--fs-toggle-knob-checked-border-color</code>
       </td>
       <td>
-        <div style={{ backgroundColor: 'var(--fs-control-bkg-default)' }} />
+        <div style={{ backgroundColor: 'var(--fs-control-bkg)' }} />
         <code>var(--fs-toggle-knob-checked-bkg-color)</code>
       </td>
     </tr>
@@ -523,9 +523,9 @@ An input checkbox styled to look like a switch button.
       </td>
       <td>
         <div
-          style={{ backgroundColor: 'var(--fs-border-color-default-active' }}
+          style={{ backgroundColor: 'var(--fs-border-color-active' }}
         />
-        <code>var(--fs-border-color-default-active)</code>
+        <code>var(--fs-border-color-active)</code>
       </td>
     </tr>
     <tr>
@@ -595,9 +595,9 @@ An input checkbox styled to look like a switch button.
       </td>
       <td>
         <div
-          style={{ backgroundColor: 'var(--fs-border-color-default-disabled)' }}
+          style={{ backgroundColor: 'var(--fs-border-color-disabled)' }}
         />
-        <code>var(--fs-border-color-default-disabled)</code>
+        <code>var(--fs-border-color-disabled)</code>
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR removes some unused `-default` variables that are being used on our code. This nomenclature was removed at #28 but after [this PR](https://github.com/vtex-sites/nextjs.store/pull/61#discussion_r885095969) in `nextjs.store`. I've checked and fount out it's being used in some places, yet.

## How does it work?

This PR just removes the `-default` nomenclature from variables where it's possible.

## How to test it?

Look around the preview and storybook. It should be working with the variables.

## References
- https://github.com/vtex-sites/nextjs.store/pull/61#discussion_r885095969)

## Checklist

<em>You may erase this after checking them all ;)</em>

- [x] Added an entry in the `CHANGELOG.md` at the beginning of its due section. [The latest version should comes first](https://keepachangelog.com/en/1.0.0/#:~:text=The%20latest%20version%20comes%20first.).
- [x] Added the PR number with the PR link at the entry in the `CHANGELOG.md`. E.g., *New items in the `pull_request_template.md` ([#12](https://github.com/vtex-sites/gatsby.store/pull/12))* 


- PR description
- [x] Updated the Storybook - *if applicable*.
- [x] Added a label according to the PR goal - `Breaking change`, `Enhancement`, `Bug` or `Chore`.
- [x] Added the component, hook, or pathname in-between backticks (``) *- If applicable*. E.g., *`ComponentName` component*.
- [x] Identified the function or parameter in the PR *- If applicable*. E.g., *`useWindowDimensions` hook*.
- [x] For documentation changes, ping @ carolinamenezes, @ PedroAntunesCosta or @ Mariana-Caetano to review and update the changes.

