### PR TITLE
feat: Add document in `QuantitySelector`

### DIFF
--- a/.storybook/components/TokenDivider.tsx
+++ b/.storybook/components/TokenDivider.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+const TokenDivider = () => {
+  return (
+    <tr>
+      <td></td>
+      <td></td>
+    </tr>
+  )
+}
+
+export default TokenDivider

--- a/.storybook/components/TokenRow.tsx
+++ b/.storybook/components/TokenRow.tsx
@@ -1,0 +1,24 @@
+import React, { ReactNode } from 'react'
+import { Code } from '@storybook/components'
+
+type TokenRowProps = {
+  token: string
+  value: string
+  isColor?: boolean
+}
+
+const TokenRow = ({ token, value, isColor = false }: TokenRowProps) => {
+  return (
+    <tr>
+      <td>
+        <Code>{token}</Code>
+      </td>
+      <td>
+        {isColor && <div style={{ backgroundColor: value }} />}
+        <Code>{value}</Code>
+      </td>
+    </tr>
+  )
+}
+
+export default TokenRow

--- a/.storybook/components/TokenTable.tsx
+++ b/.storybook/components/TokenTable.tsx
@@ -1,0 +1,33 @@
+import React, { ReactNode } from 'react'
+import { Table } from '@storybook/components'
+
+type TokenTableProps = {
+  title?: string
+  description?: string
+  children: ReactNode
+}
+
+const TokenTable = ({
+  title = 'Local token',
+  description = 'Default value/Global token linked',
+  children,
+}: TokenTableProps) => {
+  return (
+    <Table
+      style={{
+        width: '100%',
+      }}
+      className="sbdocs sbdocs-table"
+    >
+      <thead>
+        <tr>
+          <th>{title}</th>
+          <th>{description}</th>
+        </tr>
+      </thead>
+      <tbody>{children}</tbody>
+    </Table>
+  )
+}
+
+export default TokenTable

--- a/.storybook/components/index.ts
+++ b/.storybook/components/index.ts
@@ -1,0 +1,3 @@
+export { default as TokenTable } from './TokenTable'
+export { default as TokenRow } from './TokenRow'
+export { default as TokenDivider } from './TokenDivider'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add Storybook documentation for `QuantitySelector` component ([#81](https://github.com/vtex-sites/nextjs.store/pull/81))
 - Applies new local tokens to `Checkbox` ([#61](https://github.com/vtex-sites/gatsby.store/pull/61))
 - Attachments to CartItem id ([#53](https://github.com/vtex-sites/gatsby.store/pull/53))
 - Adds tests for analytics events on `CartItem` ([#66](https://github.com/vtex-sites/gatsby.store/pull/66))

--- a/src/components/ui/QuantitySelector/QuantitySelector.stories.mdx
+++ b/src/components/ui/QuantitySelector/QuantitySelector.stories.mdx
@@ -1,0 +1,176 @@
+import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs'
+
+import QuantitySelector from '.'
+import { TokenTable, TokenRow, TokenDivider } from 'src/../.storybook/components'
+
+<Meta
+  title="Molecules/QuantitySelector"
+  component={QuantitySelector}
+  argTypes={{
+    max: {
+      type: {
+        name: 'number',
+      },
+      defaultValue: 10,
+      description: "The maximum value the quantity selector can receive"
+    },
+    min: {
+      type: {
+        name: 'number',
+      },
+      defaultValue: 1,
+      description: "The minimum value the quantity selector can receive"
+    },
+    initial: {
+      type: {
+        name: 'number',
+      },
+      defaultValue: 5,
+      description: "The initial value for quantity selector"
+    },
+    disabled: {
+      type: {
+        name: 'boolean'
+      },
+      defaultValue: false,
+      description: "Specifies that the whole quantity selector component should be disabled."
+    },
+    onChange: {
+      description: "Event emitted when value is changed"
+    }
+  }}
+/>
+
+export const Template = (args) => <QuantitySelector {...args} />
+
+<header>
+
+# QuantitySelector
+
+It's a component that shows a quantity selector, commonly used to add a product to the shopping cart.
+
+</header>
+
+## Overview
+
+The `QuantitySelector` component uses [FastStore UI QuantitySelector](https://www.faststore.dev/reference/ui/molecules/QuantitySelector) as base.
+
+<Canvas>
+  <Story
+    name="Overview-QuantitySelector"
+  >
+    {Template.bind({})}
+  </Story>
+  <Story
+    name="Overview-Disabled"
+    args={{
+      disabled: true
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Usage
+
+`import QuantitySelector from '../components/sections/QuantitySelector'`
+
+<Canvas>
+  <Story
+    name="QuantitySelector"
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+<ArgsTable story="QuantitySelector" />
+
+<TokenTable>
+  <TokenRow
+    token="--fs-qty-selector-width"
+    value="calc(var(--fs-control-tap-size) * 2.7)"/>
+  <TokenRow
+    token="--fs-qty-selector-height"
+    value="calc(var(--fs-control-tap-size) + (var(--fs-qty-selector-border-width) * 2))"/>
+  <TokenDivider/>
+  <TokenRow
+    token="--fs-qty-selector-shadow"
+    value="none"/>
+  <TokenRow
+    token="--fs-qty-selector-shadow-hover"
+    value="0 0 0 var(--fs-border-width) var(--fs-border-color-active)"/>
+  <TokenDivider/>
+  <TokenRow
+    token="--fs-qty-selector-bkg-color"
+    value="var(--fs-color-body-bkg)"
+    isColor/>
+  <TokenRow
+    token="--fs-qty-selector-bkg-color-hover"
+    value="var(--fs-qty-selector-bkg-color)"
+    isColor/>
+  <TokenDivider/>
+  <TokenRow token="--fs-qty-selector-border-radius"      value="var(--fs-border-radius)"/>
+  <TokenRow token="--fs-qty-selector-border-width"       value="var(--fs-border-width)"/>
+  <TokenRow token="--fs-qty-selector-border-width-hover" value="var(--fs-border-width)"/>
+  <TokenRow token="--fs-qty-selector-border-color"       value="var(--fs-border-color)" isColor/>
+  <TokenRow token="--fs-qty-selector-border-color-hover" value="var(--fs-border-color-active)" isColor/>
+  <TokenDivider/>
+  <TokenRow token="--fs-qty-selector-transition-function" value="var(--fs-transition-function)"/>
+  <TokenRow token="--fs-qty-selector-transition-property" value="var(--fs-transition-property)"/>
+  <TokenRow token="--fs-qty-selector-transition-timing  " value="var(--fs-transition-timing)"/>
+</TokenTable>
+
+---
+
+## Nested Elements
+
+### Text
+
+<TokenTable>
+  <TokenRow token="--fs-qty-selector-text-size" value="var(--fs-text-size-base)" />
+  <TokenRow token="--fs-qty-selector-text-color" value="var(--fs-color-text)" isColor />
+  <TokenRow token="--fs-qty-selector-text-color-hover" value="var(--fs-qty-selector-text-color)" isColor />
+</TokenTable>
+
+### Icon
+
+<TokenTable>
+  <TokenRow token="--fs-qty-selector-icon-color" value="var(--fs-color-link)" isColor />
+  <TokenRow token="--fs-qty-selector-icon-color-hover" value="var(--fs-border-color-active)" isColor />
+</TokenTable>
+
+### Button
+
+<TokenTable>
+  <TokenRow token="--fs-qty-selector-button-shadow" value="none"/>
+  <TokenRow token="--fs-qty-selector-button-shadow-hover" value="none"/>
+  <TokenRow token="--fs-qty-selector-button-bkg-color" value="transparent"/>
+  <TokenRow token="--fs-qty-selector-button-bkg-color-hover" value="var(--fs-color-primary-bkg-light)" isColor  />
+  <TokenRow token="--fs-qty-selector-button-bkg-color-focus" value="var(--fs-qty-selector-button-bkg-color-hover)" isColor/>
+  <TokenRow token="--fs-qty-selector-button-border-radius"   value="var(--fs-qty-selector-border-radius)"/>
+</TokenTable>
+
+---
+
+## Variations
+
+### Disabled
+
+<Canvas>
+  <Story
+    name="Disabled"
+    args={{
+      disabled: true
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+<TokenTable>
+  <TokenRow token="--fs-qty-selector-disabled-bkg-color" value="var(--fs-color-disabled-bkg)" isColor />
+  <TokenRow token="--fs-qty-selector-disabled-text-color" value="var(--fs-color-disabled-text)" isColor />
+  <TokenRow token="--fs-qty-selector-disabled-icon-color" value="var(--fs-border-color-light-disabled)" isColor />
+  <TokenRow token="--fs-qty-selector-disabled-border-color" value="var(--fs-qty-selector-disabled-bkg-color)" isColor />
+  <TokenRow token="--fs-qty-selector-disabled-button-bkg-color" value="var(--fs-qty-selector-button-bkg-color-hover)" isColor />
+</TokenTable>

--- a/src/components/ui/QuantitySelector/QuantitySelector.stories.mdx
+++ b/src/components/ui/QuantitySelector/QuantitySelector.stories.mdx
@@ -12,32 +12,25 @@ import { TokenTable, TokenRow, TokenDivider } from 'src/../.storybook/components
         name: 'number',
       },
       defaultValue: 10,
-      description: "The maximum value the quantity selector can receive"
     },
     min: {
       type: {
         name: 'number',
       },
       defaultValue: 1,
-      description: "The minimum value the quantity selector can receive"
     },
     initial: {
       type: {
         name: 'number',
       },
       defaultValue: 5,
-      description: "The initial value for quantity selector"
     },
     disabled: {
       type: {
         name: 'boolean'
       },
       defaultValue: false,
-      description: "Specifies that the whole quantity selector component should be disabled."
     },
-    onChange: {
-      description: "Event emitted when value is changed"
-    }
   }}
 />
 

--- a/src/components/ui/QuantitySelector/QuantitySelector.tsx
+++ b/src/components/ui/QuantitySelector/QuantitySelector.tsx
@@ -5,10 +5,25 @@ import Icon from 'src/components/ui/Icon'
 import styles from './quantity-selector.module.scss'
 
 interface QuantitySelectorProps {
+  /**
+   * The maximum value the quantity selector can receive
+   */
   max?: number
+  /**
+   * The minimum value the quantity selector can receive
+   */
   min?: number
+  /**
+   * The initial value for quantity selector
+   */
   initial?: number
+  /**
+   * Specifies that the whole quantity selector component should be disabled.
+   */
   disabled?: boolean
+  /**
+   * Event emitted when value is changed
+   */
   onChange?: (value: number) => void
 }
 


### PR DESCRIPTION
Signed-off-by: Arthur Andrade <arthurfelandrade@gmail.com>

## What's the purpose of this pull request?

This PR adds storybook documentation for QuantitySelector component.

## How does it work?

Added the TokenTable and TokenRow components to make it easier to document tokens in the storybook.

## How to test it?

Run storybook and see `http://localhost:6006/?path=/docs/organisms-quantityselector--quantity-selector`.

## Checklist

<em>You may erase this after checking them all ;)</em>

- [x] Added an entry in the `CHANGELOG.md` at the beginning of its due section. [The latest version should comes first](https://keepachangelog.com/en/1.0.0/#:~:text=The%20latest%20version%20comes%20first.).
- [x] Added the PR number with the PR link at the entry in the `CHANGELOG.md`. E.g., *New items in the `pull_request_template.md` ([#4](https://github.com/vtex-sites/nextjs.store/pull/4))* 


- PR description
- [x] Updated the Storybook - *if applicable*.

