### PR TITLE
fix: Static incremental builds errors

### DIFF
--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -177,43 +177,37 @@ export const getServerData = async ({
 }) => {
   const ONE_YEAR_CACHE = `s-maxage=31536000, stale-while-revalidate`
 
-  try {
-    const { execute } = await import('src/server/index')
-    const { data } = await execute({
-      operationName: querySSR,
-      variables: { slug },
+  const { execute } = await import('src/server/index')
+  const { data, errors } = await execute({
+    operationName: querySSR,
+    variables: { slug },
+  })
+
+  if (errors && errors?.length > 0) {
+    throw new Error(`${errors[0]}`)
+  }
+
+  if (data === null) {
+    const params = new URLSearchParams({
+      from: encodeURIComponent(`/${slug}`),
     })
 
-    if (data === null) {
-      const originalUrl = `/${slug}`
-
-      return {
-        status: 301,
-        props: {},
-        headers: {
-          'cache-control': ONE_YEAR_CACHE,
-          location: `/404/?from=${encodeURIComponent(originalUrl)}`,
-        },
-      }
-    }
-
     return {
-      status: 200,
-      props: data ?? {},
-      headers: {
-        'cache-control': ONE_YEAR_CACHE,
-      },
-    }
-  } catch (err) {
-    console.error(err)
-
-    return {
-      status: 500,
+      status: 301,
       props: {},
       headers: {
-        'cache-control': 'public, max-age=0, must-revalidate',
+        'cache-control': ONE_YEAR_CACHE,
+        location: `/404/?${params.toString()}}`,
       },
     }
+  }
+
+  return {
+    status: 200,
+    props: data ?? {},
+    headers: {
+      'cache-control': ONE_YEAR_CACHE,
+    },
   }
 }
 


### PR DESCRIPTION
## What's the purpose of this pull request?
Fix wrong 404 during SSG

## How does it work?
When an error occurs while fetching data needed for pages during SSG, our code threats this as a notFound. This notFound is SSG and this page will be notFound until we make a new deploy. This PR fixes this issue by throwing and error if an error occurs, making this page to be re-generated on the next request, thus generating the right page.

## How to test it?
1. Run `yarn build && yarn serve` on your machine
2. Remove internet access (disable wifi) from your machine to simulate a communication error between the server and VTEX commerce platform
3. Enter in a PDP. You should see the 500 error page.
4. Re-enable the wifi and refresh. You should now see the correct page.


