### PR TITLE
feat: React 18 features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Changes weird if logic in suspense hooks ([#91](https://github.com/vtex-sites/gatsby.store/pull/91))
 - Uses `Hero` component from FSUI ([#92](https://github.com/vtex-sites/gatsby.store/pull/92))
 - Uses CSS Modules on `Checkbox` component ([#81](https://github.com/vtex-sites/gatsby.store/pull/81))
 - Uses CSS Modules on `QuantitySelector` component ([#75](https://github.com/vtex-sites/gatsby.store/pull/75))
@@ -42,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Removes unnecessary logic in suspense hooks ([#91](https://github.com/vtex-sites/gatsby.store/pull/91))
 - `Hero` component from `components/ui`([#92](https://github.com/vtex-sites/gatsby.store/pull/92))
 - Unused `-default` at css variables ([#82](https://github.com/vtex-sites/gatsby.store/pull/82))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Changes weird if logic in suspense hooks ([#91](https://github.com/vtex-sites/gatsby.store/pull/91))
 - Uses `Hero` component from FSUI ([#92](https://github.com/vtex-sites/gatsby.store/pull/92))
 - Uses CSS Modules on `Checkbox` component ([#81](https://github.com/vtex-sites/gatsby.store/pull/81))
 - Uses CSS Modules on `QuantitySelector` component ([#75](https://github.com/vtex-sites/gatsby.store/pull/75))

--- a/src/components/sections/ProductShelf/ProductShelf.tsx
+++ b/src/components/sections/ProductShelf/ProductShelf.tsx
@@ -8,24 +8,14 @@ import Section from '../Section'
 interface ProductShelfProps extends Partial<ProductsQueryQueryVariables> {
   title: string | JSX.Element
   withDivisor?: boolean
-  suspenseData?: boolean
-}
-
-const options = {
-  suspense: true,
-  fallbackData: { search: { products: undefined } },
 }
 
 function ProductShelf({
   title,
   withDivisor = false,
-  suspenseData,
   ...variables
 }: ProductShelfProps) {
-  const products = useProductsQuery(
-    variables,
-    suspenseData ? options : undefined
-  )
+  const products = useProductsQuery(variables)
 
   if (products?.edges.length === 0) {
     return null

--- a/src/components/sections/ProductTiles/ProductTiles.tsx
+++ b/src/components/sections/ProductTiles/ProductTiles.tsx
@@ -27,13 +27,8 @@ const getRatio = (products: number, idx: number) => {
   return 3 / 4
 }
 
-const options = {
-  suspense: true,
-  fallbackData: { search: { products: undefined } },
-}
-
 const ProductTiles = ({ title, ...variables }: TilesProps) => {
-  const products = useProductsQuery(variables, options)
+  const products = useProductsQuery(variables)
 
   if (products?.edges.length === 0) {
     return null

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,21 +1,21 @@
+import 'src/styles/pages/homepage.scss'
+
 import { useSession } from '@faststore/sdk'
 import { graphql } from 'gatsby'
 import { GatsbySeo, JsonLd } from 'gatsby-plugin-next-seo'
+import { Suspense } from 'react'
 import BannerText from 'src/components/sections/BannerText'
 import Hero from 'src/components/sections/Hero'
 import IncentivesHeader from 'src/components/sections/Incentives/IncentivesHeader'
+import IncentivesMock from 'src/components/sections/Incentives/incentivesMock'
 import ProductShelf from 'src/components/sections/ProductShelf'
 import ProductTiles from 'src/components/sections/ProductTiles'
-import { mark } from 'src/sdk/tests/mark'
+import ProductShelfSkeleton from 'src/components/skeletons/ProductShelfSkeleton'
+import ProductTilesSkeleton from 'src/components/skeletons/ProductTilesSkeleton'
 import { ITEMS_PER_SECTION } from 'src/constants'
+import { mark } from 'src/sdk/tests/mark'
 import type { PageProps } from 'gatsby'
 import type { HomePageQueryQuery } from '@generated/graphql'
-import IncentivesMock from 'src/components/sections/Incentives/incentivesMock'
-import ProductShelfSkeleton from 'src/components/skeletons/ProductShelfSkeleton'
-import { Suspense } from 'react'
-import ProductTilesSkeleton from 'src/components/skeletons/ProductTilesSkeleton'
-
-import 'src/styles/pages/homepage.scss'
 
 export type Props = PageProps<HomePageQueryQuery>
 
@@ -86,7 +86,6 @@ function Page(props: Props) {
           first={ITEMS_PER_SECTION}
           selectedFacets={[{ key: 'productClusterIds', value: '140' }]}
           title="Most Wanted"
-          suspenseData
         />
       </Suspense>
 
@@ -109,7 +108,6 @@ function Page(props: Props) {
           first={ITEMS_PER_SECTION}
           selectedFacets={[{ key: 'productClusterIds', value: '142' }]}
           title="Deals & Promotions"
-          suspenseData
         />
       </Suspense>
     </>

--- a/src/sdk/product/useProductsQuery.ts
+++ b/src/sdk/product/useProductsQuery.ts
@@ -81,7 +81,11 @@ export const useProductsQuery = (
   const { data } = useQuery<ProductsQueryQuery, ProductsQueryQueryVariables>(
     query,
     localizedVariables,
-    options
+    {
+      fallbackData: null,
+      suspense: true,
+      ...options,
+    }
   )
 
   return data?.search.products


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR simplifies a bit how we handled Suspense in our components. 

## How does it work?
Before this PR, we had [this if logic](https://github.com/vtex-sites/gatsby.store/blob/e041beb86df3f57292b497eae0ef47d91672a3af/src/components/sections/ProductShelf/ProductShelf.tsx#L27) for suspense and this [unnecessary fallback value](https://github.com/vtex-sites/gatsby.store/blob/e041beb86df3f57292b497eae0ef47d91672a3af/src/components/sections/ProductShelf/ProductShelf.tsx#L14) data on the `swr` hook. This PR removes those and makes suspense the default behavior. You can disable suspense if you wish

## How to test it?
- Nothing should have changed from master

