### PR TITLE
chore: Unify Link usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Unifies `Link` component usage by adding support for both external and client-side links ([#103](https://github.com/vtex-sites/gatsby.store/pull/103))
+
 ### Deprecated
 
 ### Removed

--- a/src/components/common/Footer/Footer.tsx
+++ b/src/components/common/Footer/Footer.tsx
@@ -24,7 +24,6 @@ function Footer() {
           <UIList variant="unordered">
             <li>
               <Link
-                as="a"
                 href="https://www.facebook.com/"
                 title="Facebook"
                 target="_blank"
@@ -39,7 +38,6 @@ function Footer() {
             </li>
             <li>
               <Link
-                as="a"
                 href="https://www.instagram.com/"
                 title="Instagram"
                 target="_blank"
@@ -54,7 +52,6 @@ function Footer() {
             </li>
             <li>
               <Link
-                as="a"
                 href="https://www.pinterest.com/"
                 title="Pinterest"
                 target="_blank"
@@ -69,7 +66,6 @@ function Footer() {
             </li>
             <li>
               <Link
-                as="a"
                 href="https://twitter.com/"
                 title="Twitter"
                 target="_blank"

--- a/src/components/common/Footer/FooterLinks.tsx
+++ b/src/components/common/Footer/FooterLinks.tsx
@@ -96,7 +96,7 @@ function LinksList({ items }: LinksListProps) {
     <UIList>
       {items.map((item) => (
         <li key={item.name}>
-          <Link variant="footer" to={item.href}>
+          <Link variant="footer" href={item.href}>
             {item.name}
           </Link>
         </li>

--- a/src/components/common/Footer/footer.scss
+++ b/src/components/common/Footer/footer.scss
@@ -137,7 +137,7 @@
       margin-top: var(--fs-spacing-0);
     }
 
-    [data-store-link] {
+    [data-fs-link] {
       display: inline-flex;
       align-items: center;
       justify-content: center;
@@ -167,7 +167,7 @@
     margin-bottom: var(--fs-spacing-2);
   }
 
-  [data-store-link] {
+  [data-fs-link] {
     display: inline-block;
     padding-left: 0;
   }

--- a/src/components/common/Navbar/Navbar.tsx
+++ b/src/components/common/Navbar/Navbar.tsx
@@ -1,5 +1,4 @@
 import { List as UIList } from '@faststore/ui'
-import { Link as LinkGatsby } from 'gatsby'
 import { Suspense, useRef, useState } from 'react'
 import CartToggle from 'src/components/cart/CartToggle'
 import SearchInput from 'src/components/common/SearchInput'
@@ -51,7 +50,7 @@ function NavLinks({ onClickLink }: NavLinksProps) {
         </li>
         {collections.map(({ href, name }) => (
           <li key={name}>
-            <Link variant="display" to={href} onClick={onClickLink}>
+            <Link variant="display" href={href} onClick={onClickLink}>
               {name}
             </Link>
           </li>
@@ -77,15 +76,15 @@ function NavbarSlider() {
     >
       <div className="navbar__modal-body">
         <header className="navbar__modal-header">
-          <LinkGatsby
-            to="/"
+          <Link
+            href="/"
             aria-label="Go to FastStore home"
             title="Go to FastStore home"
             className="navbar__logo"
             onClick={fadeOut}
           >
             <Logo />
-          </LinkGatsby>
+          </Link>
 
           <ButtonIcon
             aria-label="Close Menu"
@@ -127,14 +126,14 @@ function Navbar() {
                 icon={<Icon name="List" width={32} height={32} />}
                 onClick={openNavbar}
               />
-              <LinkGatsby
-                to="/"
+              <Link
+                href="/"
                 aria-label="Go to Faststore home"
                 title="Go to Faststore home"
                 className="navbar__logo"
               >
                 <Logo />
-              </LinkGatsby>
+              </Link>
             </>
           )}
           <SearchInput />

--- a/src/components/common/Navbar/navbar.scss
+++ b/src/components/common/Navbar/navbar.scss
@@ -186,7 +186,7 @@
     align-items: center;
   }
 
-  a {
+  [data-fs-link] {
     display: block;
     width: 100%;
   }
@@ -198,7 +198,7 @@
       padding-top: var(--fs-spacing-1);
     }
 
-    a {
+    [data-fs-link] {
       width: auto;
       padding: var(--fs-spacing-0) 0;
     }

--- a/src/components/common/SearchInput/search-input.scss
+++ b/src/components/common/SearchInput/search-input.scss
@@ -54,7 +54,7 @@
   }
 }
 
-.suggestion-product-card a {
+.suggestion-product-card [data-fs-link] {
   color: var(--fs-color-neutral-7);
   text-decoration: none;
 

--- a/src/components/product/ProductCard/ProductCard.tsx
+++ b/src/components/product/ProductCard/ProductCard.tsx
@@ -4,11 +4,12 @@ import {
   ProductCardContent as UIProductCardContent,
   ProductCardImage as UIProductCardImage,
 } from '@faststore/ui'
-import { graphql, Link } from 'gatsby'
+import { graphql } from 'gatsby'
 import { memo } from 'react'
 import { Badge, DiscountBadge } from 'src/components/ui/Badge'
 import { Image } from 'src/components/ui/Image'
 import Price from 'src/components/ui/Price'
+import Link from 'src/components/ui/Link'
 import { useFormattedPrice } from 'src/sdk/product/useFormattedPrice'
 import { useProductLink } from 'src/sdk/product/useProductLink'
 import type { ReactNode } from 'react'

--- a/src/components/product/ProductCard/product-card.module.scss
+++ b/src/components/product/ProductCard/product-card.module.scss
@@ -96,7 +96,7 @@
     grid-template-rows: 1fr auto;
     padding: var(--fs-product-card-content-padding);
 
-    a[href] {
+    [data-fs-link] {
       min-height: 100%;
       padding: 0;
       color: var(--fs-product-card-title-color);

--- a/src/components/regionalization/RegionalizationModal/RegionalizationModal.tsx
+++ b/src/components/regionalization/RegionalizationModal/RegionalizationModal.tsx
@@ -38,7 +38,7 @@ function RegionModal() {
         <div data-regionalization-modal-input>
           <RegionalizationInput closeModal={fadeOut} />
         </div>
-        <Link to="/">
+        <Link href="/">
           <span data-regionalization-modal-link>
             {"Don't know my Postal Code"}
           </span>

--- a/src/components/regionalization/RegionalizationModal/regionalization-modal.scss
+++ b/src/components/regionalization/RegionalizationModal/regionalization-modal.scss
@@ -54,7 +54,7 @@
       margin-bottom: var(--fs-spacing-6);
     }
 
-    [data-store-link] {
+    [data-fs-link] {
       display: flex;
       flex-direction: row;
       align-content: flex-start;

--- a/src/components/search/History/SearchHistory.tsx
+++ b/src/components/search/History/SearchHistory.tsx
@@ -31,7 +31,7 @@ const SearchHistory = ({ history = [] }: SearchHistoryProps) => {
           <li key={item.term} data-fs-search-suggestion-item>
             <Link
               variant="display"
-              to={item.path}
+              href={item.path}
               onClick={() => onSearchInputSelection?.(item.term, item.path)}
             >
               <Icon

--- a/src/components/search/SuggestionProductCard/SuggestionProductCard.tsx
+++ b/src/components/search/SuggestionProductCard/SuggestionProductCard.tsx
@@ -14,7 +14,7 @@ type SuggestionProductCardProps = {
 
 function SuggestionProductCard({ product, index }: SuggestionProductCardProps) {
   const { onSearchInputSelection } = useSearchInput()
-  const { onClick, to, ...linkProps } = useProductLink({
+  const { onClick, href, ...linkProps } = useProductLink({
     product,
     selectedOffer: 0,
     index,
@@ -33,12 +33,12 @@ function SuggestionProductCard({ product, index }: SuggestionProductCardProps) {
     <Card data-fs-suggestion-product-card data-testid="suggestion-product-card">
       <Link
         {...linkProps}
-        to={to}
+        href={href}
         title={name}
         variant="display"
         onClick={() => {
           onClick()
-          onSearchInputSelection?.(name, to)
+          onSearchInputSelection?.(name, href)
         }}
       >
         <CardContent>

--- a/src/components/search/SuggestionProductCard/suggestion-product-card.scss
+++ b/src/components/search/SuggestionProductCard/suggestion-product-card.scss
@@ -39,7 +39,7 @@
     align-items: baseline;
   }
 
-  [data-store-link] {
+  [data-fs-link] {
     padding: 0 var(--fs-spacing-3);
     color: inherit;
     text-decoration: none;

--- a/src/components/search/Suggestions/SuggestionsTopSearch.tsx
+++ b/src/components/search/Suggestions/SuggestionsTopSearch.tsx
@@ -48,7 +48,7 @@ const SuggestionsTopSearch = forwardRef<
           <li key={term.value} data-fs-search-suggestion-item>
             <Link
               variant="display"
-              to={formatSearchPath(term.value)}
+              href={formatSearchPath(term.value)}
               onClick={() =>
                 onSearchInputSelection?.(
                   term.value,

--- a/src/components/search/Suggestions/suggestions.scss
+++ b/src/components/search/Suggestions/suggestions.scss
@@ -43,7 +43,7 @@
     background-color: var(--fs-color-main-0);
   }
 
-  [data-store-link] {
+  [data-fs-link] {
     display: flex;
     align-items: center;
     justify-content: flex-start;

--- a/src/components/sections/BannerText/BannerText.tsx
+++ b/src/components/sections/BannerText/BannerText.tsx
@@ -68,7 +68,7 @@ function BannerText({
           </div>
           <BannerLink data-fs-banner-text-link>
             <ButtonLink
-              to={actionPath}
+              href={actionPath}
               variant={variant}
               inverse={colorVariant === 'main'}
             >

--- a/src/components/sections/BannerText/banner-text.scss
+++ b/src/components/sections/BannerText/banner-text.scss
@@ -56,7 +56,7 @@
     align-items: center;
   }
 
-  [data-fs-banner-text-link] a {
+  [data-fs-banner-text-link] [data-fs-link] {
     min-width: var(--fs-banner-link-min-width);
     margin-top: var(--fs-banner-link-margin-top);
   }

--- a/src/components/sections/Hero/Hero.tsx
+++ b/src/components/sections/Hero/Hero.tsx
@@ -60,7 +60,7 @@ const Hero = ({
               <h1 id="hero-heading">{title}</h1>
               <p data-fs-hero-text-body>{subtitle}</p>
               {!!link && (
-                <ButtonLink to={link} inverse={colorVariant === 'main'}>
+                <ButtonLink href={link} inverse={colorVariant === 'main'}>
                   {linkText} <Icon name="ArrowRight" width={24} height={24} />
                 </ButtonLink>
               )}

--- a/src/components/sections/ProductGallery/EmptyGallery.tsx
+++ b/src/components/sections/ProductGallery/EmptyGallery.tsx
@@ -12,7 +12,7 @@ function EmptyGallery() {
       </header>
 
       <ButtonLink
-        to="/office"
+        href="/office"
         variant="secondary"
         icon={
           <Icon name="CircleWavyWarning" width={18} height={18} weight="bold" />
@@ -22,7 +22,7 @@ function EmptyGallery() {
         Browse Offers
       </ButtonLink>
       <ButtonLink
-        to="/technology"
+        href="/technology"
         variant="secondary"
         icon={<Icon name="RocketLaunch" width={18} height={18} weight="bold" />}
         iconPosition="left"

--- a/src/components/sections/ProductGallery/ProductGallery.tsx
+++ b/src/components/sections/ProductGallery/ProductGallery.tsx
@@ -1,6 +1,7 @@
 import { useSearch } from '@faststore/sdk'
 import { GatsbySeo } from 'gatsby-plugin-next-seo'
 import { lazy, Suspense } from 'react'
+import type { MouseEvent } from 'react'
 import Filter from 'src/components/search/Filter'
 import Sort from 'src/components/search/Sort'
 import FilterSkeleton from 'src/components/skeletons/FilterSkeleton'
@@ -102,12 +103,12 @@ function ProductGallery({ title, searchTerm }: Props) {
             <div data-fs-product-listing-pagination="top">
               <GatsbySeo defer linkTags={[{ rel: 'prev', href: prev.link }]} />
               <ButtonLink
-                onClick={(e) => {
+                onClick={(e: MouseEvent<HTMLElement>) => {
                   e.currentTarget.blur()
                   e.preventDefault()
                   addPrevPage()
                 }}
-                to={prev.link}
+                href={prev.link}
                 rel="prev"
                 variant="secondary"
                 iconPosition="left"
@@ -142,12 +143,12 @@ function ProductGallery({ title, searchTerm }: Props) {
               <GatsbySeo defer linkTags={[{ rel: 'next', href: next.link }]} />
               <ButtonLink
                 data-testid="show-more"
-                onClick={(e) => {
+                onClick={(e: MouseEvent<HTMLElement>) => {
                   e.currentTarget.blur()
                   e.preventDefault()
                   addNextPage()
                 }}
-                to={next.link}
+                href={next.link}
                 rel="next"
                 variant="secondary"
               >

--- a/src/components/ui/Alert/Alert.tsx
+++ b/src/components/ui/Alert/Alert.tsx
@@ -1,8 +1,8 @@
 import { Alert as UIAlert, Icon as UIIcon } from '@faststore/ui'
-import { Link } from 'gatsby'
 import { useCallback } from 'react'
 import Button from 'src/components/ui/Button'
 import Icon from 'src/components/ui/Icon'
+import Link from 'src/components/ui/Link'
 import type { ReactNode, MouseEvent } from 'react'
 import type { AlertProps } from '@faststore/ui'
 
@@ -58,7 +58,7 @@ function Alert({
       <p data-fs-alert-content>{children}</p>
 
       {link && (
-        <Link data-fs-alert-link to={link.to}>
+        <Link data-fs-alert-link href={link.to}>
           {link.text}
         </Link>
       )}

--- a/src/components/ui/Alert/Alert.tsx
+++ b/src/components/ui/Alert/Alert.tsx
@@ -58,7 +58,7 @@ function Alert({
       <p data-fs-alert-content>{children}</p>
 
       {link && (
-        <Link data-fs-alert-link href={link.to}>
+        <Link data-fs-alert-link variant="inline" href={link.to}>
           {link.text}
         </Link>
       )}

--- a/src/components/ui/Alert/alert.module.scss
+++ b/src/components/ui/Alert/alert.module.scss
@@ -49,8 +49,6 @@
   span { font-weight: var(--fs-text-weight-bold); }
 
   [data-fs-alert-link] {
-    display: flex;
-    align-items: center;
     min-width: 0;
     height: var(--fs-alert-height);
     padding: 0 var(--fs-spacing-1);

--- a/src/components/ui/Alert/alert.module.scss
+++ b/src/components/ui/Alert/alert.module.scss
@@ -49,6 +49,8 @@
   span { font-weight: var(--fs-text-weight-bold); }
 
   [data-fs-alert-link] {
+    display: flex;
+    align-items: center;
     min-width: 0;
     height: var(--fs-alert-height);
     padding: 0 var(--fs-spacing-1);

--- a/src/components/ui/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/ui/Breadcrumb/Breadcrumb.tsx
@@ -42,7 +42,7 @@ function BaseBreadcrumb({
       divider=""
       className={isDesktop ? 'hidden-mobile' : 'display-mobile'}
     >
-      <Link aria-label="Go to homepage" to="/">
+      <Link aria-label="Go to homepage" href="/">
         <Icon name="House" width={18} height={18} weight="bold" />
       </Link>
 
@@ -51,14 +51,14 @@ function BaseBreadcrumb({
           return breadcrumbList.length === index + 1 ? (
             <span key={String(index)}>{name}</span>
           ) : (
-            <Link to={item} key={String(index)}>
+            <Link href={item} key={String(index)}>
               {name}
             </Link>
           )
         })}
 
       {collapseBreadcrumb && firstItem && (
-        <Link to={firstItem.item}>{firstItem.name}</Link>
+        <Link href={firstItem.item}>{firstItem.name}</Link>
       )}
 
       {collapseBreadcrumb && (
@@ -86,7 +86,7 @@ function BaseBreadcrumb({
           return lastItems.length === index + 1 ? (
             <span key={String(index)}>{name}</span>
           ) : (
-            <Link to={item} key={String(index)}>
+            <Link href={item} key={String(index)}>
               {name}
             </Link>
           )

--- a/src/components/ui/Breadcrumb/breadcrumb.scss
+++ b/src/components/ui/Breadcrumb/breadcrumb.scss
@@ -18,7 +18,7 @@
       align-items: center;
       padding: var(--fs-spacing-0);
 
-      &:first-child a {
+      &:first-child [data-fs-link] {
         display: flex;
         align-items: center;
         padding: var(--fs-spacing-1);
@@ -70,7 +70,7 @@
       border-left: var(--fs-border-width) solid var(--fs-border-color-light);
     }
 
-    [data-store-link] {
+    [data-fs-link] {
       padding: 0;
 
       &:visited {

--- a/src/components/ui/Button/ButtonLink/ButtonLink.tsx
+++ b/src/components/ui/Button/ButtonLink/ButtonLink.tsx
@@ -7,8 +7,7 @@ import type { LinkProps } from 'src/components/ui/Link'
 import type { ButtonProps } from '../Button'
 import styles from '../button.module.scss'
 
-type ButtonLinkProps = ButtonProps &
-  Omit<LinkProps, 'variant'> & { disabled?: boolean }
+type ButtonLinkProps = ButtonProps & Omit<LinkProps, 'variant'>
 
 function ButtonLink({
   variant = 'primary',

--- a/src/components/ui/Button/ButtonLink/ButtonLink.tsx
+++ b/src/components/ui/Button/ButtonLink/ButtonLink.tsx
@@ -23,7 +23,7 @@ function ButtonLink({
 
   return (
     <Link
-      innerRef={linkRef}
+      ref={linkRef}
       className={styles.fsButton}
       data-fs-button
       data-fs-button-link

--- a/src/components/ui/Button/ButtonLink/ButtonLink.tsx
+++ b/src/components/ui/Button/ButtonLink/ButtonLink.tsx
@@ -1,16 +1,14 @@
-import { Icon as UIIcon, Link as UILink } from '@faststore/ui'
-import { Link as GatsbyLink } from 'gatsby'
 import { useRef } from 'react'
-import type { LinkProps } from '@faststore/ui'
 import type { FocusEvent } from 'react'
+import { Icon as UIIcon } from '@faststore/ui'
+import Link from 'src/components/ui/Link'
+import type { LinkProps } from 'src/components/ui/Link'
 
 import type { ButtonProps } from '../Button'
 import styles from '../button.module.scss'
 
-type Props = {
-  disabled?: boolean
-} & ButtonProps &
-  LinkProps<typeof GatsbyLink>
+type ButtonLinkProps = ButtonProps &
+  Omit<LinkProps, 'variant'> & { disabled?: boolean }
 
 function ButtonLink({
   variant = 'primary',
@@ -20,12 +18,11 @@ function ButtonLink({
   children,
   disabled = false,
   ...otherProps
-}: Props) {
+}: ButtonLinkProps) {
   const linkRef = useRef<HTMLAnchorElement | null>(null)
 
   return (
-    <UILink
-      as={GatsbyLink}
+    <Link
       innerRef={linkRef}
       className={styles.fsButton}
       data-fs-button
@@ -45,7 +42,7 @@ function ButtonLink({
       {iconPosition === 'left' && <UIIcon component={icon} />}
       {children}
       {iconPosition === 'right' && <UIIcon component={icon} />}
-    </UILink>
+    </Link>
   )
 }
 

--- a/src/components/ui/Button/ButtonLink/ButtonSignIn/ButtonSignIn.tsx
+++ b/src/components/ui/Button/ButtonLink/ButtonSignIn/ButtonSignIn.tsx
@@ -9,7 +9,7 @@ const ButtonSignIn = () => {
   return (
     <ButtonLink
       data-fs-button-signin-link
-      to={person?.id ? '/account' : '/login'}
+      href={person?.id ? '/account' : '/login'}
       className={`${styles.fsButton} text__title-mini signin-link`}
       variant="tertiary"
     >

--- a/src/components/ui/Button/ButtonLink/ButtonSignIn/ButtonSignInFallback/ButtonSignInFallback.tsx
+++ b/src/components/ui/Button/ButtonLink/ButtonSignIn/ButtonSignInFallback/ButtonSignInFallback.tsx
@@ -5,7 +5,7 @@ function ButtonSignInFallback() {
   return (
     <ButtonLink
       data-fs-button-signin-link
-      to="/login"
+      href="/login"
       className="text__title-mini signin-link"
       variant="tertiary"
     >

--- a/src/components/ui/EmptyState/empty-state.scss
+++ b/src/components/ui/EmptyState/empty-state.scss
@@ -29,7 +29,7 @@
     }
   }
 
-  a {
+  [data-fs-link] {
     min-width: rem(190px);
   }
 }

--- a/src/components/ui/Link/Link.stories.tsx
+++ b/src/components/ui/Link/Link.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: Link,
   title: 'Atoms/Link',
   argTypes: {
-    to: {
+    href: {
       type: { name: 'string', required: true },
     },
     ref: {
@@ -39,7 +39,7 @@ const Template = ({ inverse, ...args }: LinkProps) =>
 export const Default = Template.bind({})
 
 Default.args = {
-  to: '#',
+  href: '#',
   variant: 'default',
   inverse: false,
 }
@@ -47,7 +47,7 @@ Default.args = {
 export const Display = Template.bind({})
 
 Display.args = {
-  to: '#',
+  href: '#',
   variant: 'display',
   inverse: false,
 }
@@ -55,7 +55,7 @@ Display.args = {
 export const Footer = Template.bind({})
 
 Footer.args = {
-  to: '#',
+  href: '#',
   variant: 'footer',
   inverse: false,
 }
@@ -63,7 +63,7 @@ Footer.args = {
 export const Inline = Template.bind({})
 
 Inline.args = {
-  to: '#',
+  href: '#',
   variant: 'inline',
   inverse: false,
 }

--- a/src/components/ui/Link/Link.tsx
+++ b/src/components/ui/Link/Link.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react'
+import { forwardRef, useMemo } from 'react'
 import type { Ref, ElementType, AnchorHTMLAttributes } from 'react'
 import { Link as GatsbyLink } from 'gatsby'
 import type { GatsbyLinkProps } from 'gatsby'
@@ -8,7 +8,7 @@ import type { LinkProps as UILinkProps } from '@faststore/ui'
 import styles from './link.module.scss'
 
 // From Gatsby's internals: https://github.com/gatsbyjs/gatsby/blob/2975c4d1271e3da52b531ad2f49261c362e5ae13/packages/gatsby-link/src/index.js#L42-L46
-function isExternalLink(href: string) {
+function externalLinkChecker(href: string) {
   return (
     href.startsWith('//') ||
     href.startsWith('http://') ||
@@ -25,31 +25,50 @@ export type LinkProps<T extends ElementType = 'a'> = UILinkProps<T> &
     href: string
     variant?: Variant
     inverse?: boolean
+    externalLink?: boolean
   }
 
 const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link<
   T extends ElementType = 'a'
 >(
-  { href, inverse, children, variant = 'default', ...otherProps }: LinkProps<T>,
+  {
+    href,
+    inverse,
+    children,
+    externalLink,
+    variant = 'default',
+    ...otherProps
+  }: LinkProps<T>,
   ref: Ref<HTMLAnchorElement> | undefined
 ) {
-  const defaultProps = {
-    'data-fs-link': true,
-    'data-fs-link-variant': variant,
-    'data-fs-link-inverse': inverse,
-    className: styles.fsLink,
-  }
+  const isExternalLink = useMemo(() => externalLinkChecker(href), [href])
 
-  if (isExternalLink(href)) {
+  if (externalLink || isExternalLink) {
     return (
-      <UILink ref={ref} href={href} {...defaultProps} {...otherProps}>
+      <UILink
+        ref={ref}
+        href={href}
+        data-fs-link
+        data-fs-link-variant={variant}
+        data-fs-link-inverse={inverse}
+        className={styles.fsLink}
+        {...otherProps}
+      >
         {children}
       </UILink>
     )
   }
 
   return (
-    <UILink as={GatsbyLink} to={href} {...defaultProps} {...otherProps}>
+    <UILink
+      as={GatsbyLink}
+      to={href}
+      data-fs-link
+      data-fs-link-variant={variant}
+      data-fs-link-inverse={inverse}
+      className={styles.fsLink}
+      {...otherProps}
+    >
       {children}
     </UILink>
   )

--- a/src/components/ui/Link/Link.tsx
+++ b/src/components/ui/Link/Link.tsx
@@ -7,15 +7,6 @@ import type { LinkProps as UILinkProps } from '@faststore/ui'
 
 import styles from './link.module.scss'
 
-// From Gatsby's internals: https://github.com/gatsbyjs/gatsby/blob/2975c4d1271e3da52b531ad2f49261c362e5ae13/packages/gatsby-link/src/index.js#L42-L46
-function externalLinkChecker(href: string) {
-  return (
-    href.startsWith('//') ||
-    href.startsWith('http://') ||
-    href.startsWith('https://')
-  )
-}
-
 type Variant = 'default' | 'display' | 'footer' | 'inline'
 type FrameworkLinkProps = Omit<GatsbyLinkProps<Record<string, unknown>>, 'to'>
 
@@ -25,29 +16,24 @@ export type LinkProps<T extends ElementType = 'a'> = UILinkProps<T> &
     href: string
     variant?: Variant
     inverse?: boolean
-    externalLink?: boolean
   }
 
 const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link<
   T extends ElementType = 'a'
 >(
-  {
-    href,
-    inverse,
-    children,
-    externalLink,
-    variant = 'default',
-    ...otherProps
-  }: LinkProps<T>,
+  { href, inverse, children, variant = 'default', ...otherProps }: LinkProps<T>,
   ref: Ref<HTMLAnchorElement> | undefined
 ) {
-  const isExternalLink = useMemo(() => externalLinkChecker(href), [href])
+  const isInternalLink = useMemo(
+    () => href[0] === '/' && href[1] !== '/',
+    [href]
+  )
 
-  if (externalLink || isExternalLink) {
+  if (isInternalLink) {
     return (
       <UILink
-        ref={ref}
-        href={href}
+        as={GatsbyLink}
+        to={href}
         data-fs-link
         data-fs-link-variant={variant}
         data-fs-link-inverse={inverse}
@@ -61,8 +47,8 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link<
 
   return (
     <UILink
-      as={GatsbyLink}
-      to={href}
+      ref={ref}
+      href={href}
       data-fs-link
       data-fs-link-variant={variant}
       data-fs-link-inverse={inverse}

--- a/src/components/ui/Link/Link.tsx
+++ b/src/components/ui/Link/Link.tsx
@@ -1,4 +1,5 @@
-import type { ElementType } from 'react'
+import { forwardRef } from 'react'
+import type { Ref, ElementType, AnchorHTMLAttributes } from 'react'
 import { Link as GatsbyLink } from 'gatsby'
 import type { GatsbyLinkProps } from 'gatsby'
 import { Link as UILink } from '@faststore/ui'
@@ -9,29 +10,29 @@ import styles from './link.module.scss'
 // From Gatsby's internals: https://github.com/gatsbyjs/gatsby/blob/2975c4d1271e3da52b531ad2f49261c362e5ae13/packages/gatsby-link/src/index.js#L42-L46
 function isExternalLink(href: string) {
   return (
+    href.startsWith('//') ||
     href.startsWith('http://') ||
-    href.startsWith('https://') ||
-    href.startsWith('//')
+    href.startsWith('https://')
   )
 }
 
 type Variant = 'default' | 'display' | 'footer' | 'inline'
 type FrameworkLinkProps = Omit<GatsbyLinkProps<Record<string, unknown>>, 'to'>
 
-export type LinkProps<T extends ElementType = ElementType<FrameworkLinkProps>> =
+export type LinkProps<T extends ElementType = 'a'> = UILinkProps<T> &
   FrameworkLinkProps &
-    UILinkProps<T> & {
-      href: string
-      variant?: Variant
-      inverse?: boolean
-    }
+  AnchorHTMLAttributes<HTMLAnchorElement> & {
+    href: string
+    variant?: Variant
+    inverse?: boolean
+  }
 
-function Link<T extends ElementType = ElementType<FrameworkLinkProps>>({
-  href,
-  inverse,
-  variant = 'default',
-  ...otherProps
-}: LinkProps<T>) {
+const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link<
+  T extends ElementType = 'a'
+>(
+  { href, inverse, children, variant = 'default', ...otherProps }: LinkProps<T>,
+  ref: Ref<HTMLAnchorElement> | undefined
+) {
   const defaultProps = {
     'data-fs-link': true,
     'data-fs-link-variant': variant,
@@ -40,10 +41,18 @@ function Link<T extends ElementType = ElementType<FrameworkLinkProps>>({
   }
 
   if (isExternalLink(href)) {
-    return <UILink href={href} {...defaultProps} {...otherProps} />
+    return (
+      <UILink ref={ref} href={href} {...defaultProps} {...otherProps}>
+        {children}
+      </UILink>
+    )
   }
 
-  return <UILink as={GatsbyLink} to={href} {...defaultProps} {...otherProps} />
-}
+  return (
+    <UILink as={GatsbyLink} to={href} {...defaultProps} {...otherProps}>
+      {children}
+    </UILink>
+  )
+})
 
 export default Link

--- a/src/components/ui/Link/Link.tsx
+++ b/src/components/ui/Link/Link.tsx
@@ -1,35 +1,49 @@
-import { Link as UILink } from '@faststore/ui'
-import { Link as GatsbyLink } from 'gatsby'
 import type { ElementType } from 'react'
+import { Link as GatsbyLink } from 'gatsby'
+import type { GatsbyLinkProps } from 'gatsby'
+import { Link as UILink } from '@faststore/ui'
 import type { LinkProps as UILinkProps } from '@faststore/ui'
 
 import styles from './link.module.scss'
 
+// From Gatsby's internals: https://github.com/gatsbyjs/gatsby/blob/2975c4d1271e3da52b531ad2f49261c362e5ae13/packages/gatsby-link/src/index.js#L42-L46
+function isExternalLink(href: string) {
+  return (
+    href.startsWith('http://') ||
+    href.startsWith('https://') ||
+    href.startsWith('//')
+  )
+}
+
 type Variant = 'default' | 'display' | 'footer' | 'inline'
+type FrameworkLinkProps = Omit<GatsbyLinkProps<Record<string, unknown>>, 'to'>
 
-export type LinkProps<T extends ElementType = typeof GatsbyLink> =
-  UILinkProps<T> & {
-    variant?: Variant
-    inverse?: boolean
-  }
+export type LinkProps<T extends ElementType = ElementType<FrameworkLinkProps>> =
+  FrameworkLinkProps &
+    UILinkProps<T> & {
+      href: string
+      variant?: Variant
+      inverse?: boolean
+    }
 
-function Link<T extends ElementType = typeof GatsbyLink>({
-  variant = 'default',
+function Link<T extends ElementType = ElementType<FrameworkLinkProps>>({
+  href,
   inverse,
-  to,
+  variant = 'default',
   ...otherProps
 }: LinkProps<T>) {
-  return (
-    <UILink
-      as={GatsbyLink}
-      data-fs-link
-      data-fs-link-variant={variant}
-      data-fs-link-inverse={inverse}
-      className={styles.fsLink}
-      to={to}
-      {...otherProps}
-    />
-  )
+  const defaultProps = {
+    'data-fs-link': true,
+    'data-fs-link-variant': variant,
+    'data-fs-link-inverse': inverse,
+    className: styles.fsLink,
+  }
+
+  if (isExternalLink(href)) {
+    return <UILink href={href} {...defaultProps} {...otherProps} />
+  }
+
+  return <UILink as={GatsbyLink} to={href} {...defaultProps} {...otherProps} />
 }
 
 export default Link

--- a/src/components/ui/Link/link.module.scss
+++ b/src/components/ui/Link/link.module.scss
@@ -1,6 +1,6 @@
 @import "src/styles/scaffold";
 
-.fs-link[data-fs-link] {
+.fs-link {
   // --------------------------------------------------------
   // Design Tokens for Link
   // --------------------------------------------------------

--- a/src/components/ui/Search/Suggestions/Suggestions.tsx
+++ b/src/components/ui/Search/Suggestions/Suggestions.tsx
@@ -79,7 +79,7 @@ function Suggestions({
           {terms?.map(({ value: suggestion }) => (
             <li key={suggestion} data-fs-search-suggestion-item>
               <Link
-                to={formatSearchPath(suggestion)}
+                href={formatSearchPath(suggestion)}
                 onClick={() => {
                   onSearchInputSelection?.(
                     suggestion,

--- a/src/sdk/product/useProductLink.ts
+++ b/src/sdk/product/useProductLink.ts
@@ -62,7 +62,7 @@ export const useProductLink = ({
   }, [code, product, index, selectedOffer, href])
 
   return {
-    to: `/${slug}/p`,
+    href: `/${slug}/p`,
     onClick,
     'data-testid': 'product-link',
   }


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to unify the `Link` component usage by refactoring it to handle both external and client-side navigation.

## How does it work?

For client-side navigation, we continue to work with the framework standards, using Gatsby's Link after checking the `href` attribute.

For external navigation, we use `Link` normally as an anchor element.

## How to test it?

Even after these changes, links should work as before.

## References

- [Gatsby's official repo issue #16682](https://github.com/gatsbyjs/gatsby/issues/16682);
- [Wrapping Gatsby's Link with Typescript](https://www.charpeni.com/blog/wrapping-gatsbys-link-with-typescript);

## Checklist

**Changelog**
- [x] Added an entry in the `CHANGELOG.md` at the beginning of its due section. [The latest version should comes first](https://keepachangelog.com/en/1.0.0/#:~:text=The%20latest%20version%20comes%20first.).
- [x] Added the PR number with the PR link at the entry in the `CHANGELOG.md`. E.g., *New items in the `pull_request_template.md` ([#12](https://github.com/vtex-sites/gatsby.store/pull/12))*

**PR Description**
- [x] Added a label according to the PR goal - `Breaking change`, `Enhancement`, `Bug` or `Chore`.
- [x] Added the component, hook, or pathname in-between backticks (``) *- If applicable*. E.g., *`ComponentName` component*.
- [x] Identified the function or parameter in the PR *- If applicable*. E.g., *`useWindowDimensions` hook*.

**Documentation**
- [x] PR description