### PR TITLE
Fix a local failing test related to the infinite scroll pagination

### DIFF
--- a/cypress/integration/plp.test.js
+++ b/cypress/integration/plp.test.js
@@ -187,6 +187,7 @@ describe('Infinite Scroll pagination', () => {
               })
               .then(() => {
                 cy.go('back')
+                cy.reload()
                   .get(
                     '[data-testid=product-gallery] [data-testid=store-product-card]'
                   )


### PR DESCRIPTION
## What's the purpose of this pull request?

There's a test that is failing because of some with the Back button on [Gatsby](https://github.com/gatsbyjs/gatsby/issues/29469) that is causing a 404 for an existing route. This error happens **only in development** and is causing this test to fail, so it's not an issue on CI running on production. The purpose of this PR is to fix this test so we don't have any failing tests in development mode.

![CleanShot 2022-06-21 at 12 26 11](https://user-images.githubusercontent.com/381395/174838234-0dd5c970-81a6-4d78-908d-9108f392b4b2.png)

## How does it work?

Triggering a page refresh after going back in history fixes the test.

Before|After
-|-
![Screen Shot 2022-06-21 at 12 54 20](https://user-images.githubusercontent.com/381395/174848275-926e56d8-973a-459d-a190-eed8d2894393.png)|![Screen Shot 2022-06-21 at 12 38 05](https://user-images.githubusercontent.com/381395/174848294-e83bb72f-e1c1-4bd3-be83-bf1ba93d95e9.png)

## How to test it?

Run the app with `yarn develop` and then run the failing test with `yarn cypress run -s cypress/integration/plp.test.js`. It should now pass.

## References

- https://github.com/gatsbyjs/gatsby/issues/7261
- https://github.com/gatsbyjs/gatsby/issues/29469