### PR TITLE
[WIP] chore: Uses suspense to display skeletons for `ProductTiles` and `ProductShelf` sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Uses Suspense to render skeletons for `ProductShelf` and `ProductTiles`sections ([#119](https://github.com/vtex-sites/gatsby.store/pull/119))
 - Move logo's svg code from JS into static asset ([#116](https://github.com/vtex-sites/gatsby.store/pull/116))
 - Upgrade dependencies ([#114](https://github.com/vtex-sites/gatsby.store/pull/114))
 - Storybook's version from 6.4.20 to 6.5.9 ([#109](https://github.com/vtex-sites/gatsby.store/pull/109))

--- a/src/components/sections/ProductShelf/ProductShelf.tsx
+++ b/src/components/sections/ProductShelf/ProductShelf.tsx
@@ -1,11 +1,11 @@
-import ProductShelfSkeleton from 'src/components/skeletons/ProductShelfSkeleton'
 import { useProductsQuery } from 'src/sdk/product/useProductsQuery'
 import type { ProductsQueryQueryVariables } from '@generated/graphql'
 
 import ProductCard from '../../product/ProductCard'
 import Section from '../Section'
 
-interface ProductShelfProps extends Partial<ProductsQueryQueryVariables> {
+export interface ProductShelfProps
+  extends Partial<ProductsQueryQueryVariables> {
   title: string | JSX.Element
   withDivisor?: boolean
 }
@@ -27,15 +27,13 @@ function ProductShelf({
     >
       <h2 className="text__title-section layout__content">{title}</h2>
       <div data-fs-product-shelf>
-        <ProductShelfSkeleton loading={products === undefined}>
-          <ul data-fs-product-shelf-items className="layout__content">
-            {products?.edges.map((product, idx) => (
-              <li key={`${product.node.id}`}>
-                <ProductCard product={product.node} index={idx + 1} />
-              </li>
-            ))}
-          </ul>
-        </ProductShelfSkeleton>
+        <ul data-fs-product-shelf-items className="layout__content">
+          {products?.edges.map((product, idx) => (
+            <li key={`${product.node.id}`}>
+              <ProductCard product={product.node} index={idx + 1} />
+            </li>
+          ))}
+        </ul>
       </div>
     </Section>
   )

--- a/src/components/sections/ProductShelf/index.tsx
+++ b/src/components/sections/ProductShelf/index.tsx
@@ -1,1 +1,15 @@
-export { default } from './ProductShelf'
+import { lazy, Suspense } from 'react'
+import ProductShelfSkeleton from 'src/components/skeletons/ProductShelfSkeleton'
+import type { ProductShelfProps } from 'src/components/sections/ProductShelf/ProductShelf'
+
+const ProductShelfComponent = lazy(
+  () => import('src/components/sections/ProductShelf/ProductShelf')
+)
+
+export default function ProductShelf(props: ProductShelfProps) {
+  return (
+    <Suspense fallback={<ProductShelfSkeleton title={props.title} loading />}>
+      <ProductShelfComponent {...props} />
+    </Suspense>
+  )
+}

--- a/src/components/sections/ProductTiles/ProductTiles.tsx
+++ b/src/components/sections/ProductTiles/ProductTiles.tsx
@@ -1,12 +1,11 @@
 import Tiles, { Tile } from 'src/components/ui/Tiles'
 import ProductCard from 'src/components/product/ProductCard'
-import ProductTilesSkeleton from 'src/components/skeletons/ProductTilesSkeleton'
 import { useProductsQuery } from 'src/sdk/product/useProductsQuery'
 import type { ProductsQueryQueryVariables } from '@generated/graphql'
 
 import Section from '../Section'
 
-interface TilesProps extends Partial<ProductsQueryQueryVariables> {
+export interface TilesProps extends Partial<ProductsQueryQueryVariables> {
   title: string | JSX.Element
 }
 
@@ -38,21 +37,19 @@ const ProductTiles = ({ title, ...variables }: TilesProps) => {
     <Section className="layout__section layout__content">
       <h2 className="text__title-section">{title}</h2>
       <div>
-        <ProductTilesSkeleton variant="wide" loading={!products}>
-          <Tiles>
-            {products?.edges.map((product, idx) => (
-              <Tile key={product.node.id}>
-                <ProductCard
-                  data-testid="tile-card"
-                  product={product.node}
-                  index={idx + 1}
-                  variant="wide"
-                  aspectRatio={getRatio(products.edges.length, idx)}
-                />
-              </Tile>
-            ))}
-          </Tiles>
-        </ProductTilesSkeleton>
+        <Tiles>
+          {products?.edges.map((product, idx) => (
+            <Tile key={product.node.id}>
+              <ProductCard
+                data-testid="tile-card"
+                product={product.node}
+                index={idx + 1}
+                variant="wide"
+                aspectRatio={getRatio(products.edges.length, idx)}
+              />
+            </Tile>
+          ))}
+        </Tiles>
       </div>
     </Section>
   )

--- a/src/components/sections/ProductTiles/index.tsx
+++ b/src/components/sections/ProductTiles/index.tsx
@@ -1,1 +1,15 @@
-export { default } from './ProductTiles'
+import { lazy, Suspense } from 'react'
+import ProductTilesSkeleton from 'src/components/skeletons/ProductTilesSkeleton'
+import type { TilesProps } from 'src/components/sections/ProductTiles/ProductTiles'
+
+const ProductTilesComponent = lazy(
+  () => import('src/components/sections/ProductTiles/ProductTiles')
+)
+
+export default function ProductTiles(props: TilesProps) {
+  return (
+    <Suspense fallback={<ProductTilesSkeleton title={props.title} loading />}>
+      <ProductTilesComponent {...props} />
+    </Suspense>
+  )
+}

--- a/src/components/skeletons/ProductShelfSkeleton/ProductShelfSkeleton.tsx
+++ b/src/components/skeletons/ProductShelfSkeleton/ProductShelfSkeleton.tsx
@@ -1,24 +1,32 @@
 import { ITEMS_PER_SECTION } from 'src/constants'
 import type { PropsWithChildren } from 'react'
+import Section from 'src/components/sections/Section'
 
 import ProductCardSkeleton from '../ProductCardSkeleton'
 
 interface Props {
+  title: string | JSX.Element
   loading?: boolean
 }
 
 function ProductShelfSkeleton({
   children,
+  title,
   loading = true,
 }: PropsWithChildren<Props>) {
   return loading ? (
-    <ul data-fs-product-shelf-items className="layout__content">
-      {Array.from({ length: ITEMS_PER_SECTION }, (_, index) => (
-        <li key={String(index)}>
-          <ProductCardSkeleton sectioned />
-        </li>
-      ))}
-    </ul>
+    <Section className="layout__section">
+      <h2 className="text__title-section layout__content">{title}</h2>
+      <div data-fs-product-shelf>
+        <ul data-fs-product-shelf-items className="layout__content">
+          {Array.from({ length: ITEMS_PER_SECTION }, (_, index) => (
+            <li key={String(index)}>
+              <ProductCardSkeleton sectioned />
+            </li>
+          ))}
+        </ul>
+      </div>
+    </Section>
   ) : (
     <>{children}</>
   )

--- a/src/components/skeletons/ProductTilesSkeleton/ProductTilesSkeleton.tsx
+++ b/src/components/skeletons/ProductTilesSkeleton/ProductTilesSkeleton.tsx
@@ -1,4 +1,5 @@
 import type { PropsWithChildren } from 'react'
+import Section from 'src/components/sections/Section'
 import Tiles, { Tile } from 'src/components/ui/Tiles'
 
 import ProductTileSkeleton from './ProductTileSkeleton'
@@ -8,22 +9,29 @@ const DEFAULT_ITEMS_NUMBER = 3
 
 interface Props {
   loading?: boolean
+  title: string | JSX.Element
   variant?: 'wide' | 'default'
 }
 
 function ProductTilesSkeleton({
   children,
   loading = true,
+  title,
   variant = 'default',
 }: PropsWithChildren<Props>) {
   return loading ? (
-    <Tiles>
-      {Array.from({ length: DEFAULT_ITEMS_NUMBER }, (_, index) => (
-        <Tile key={String(index)}>
-          <ProductTileSkeleton tileIndex={index + 1} variant={variant} />
-        </Tile>
-      ))}
-    </Tiles>
+    <Section className="layout__section layout__content">
+      <h2 className="text__title-section">{title}</h2>
+      <div>
+        <Tiles>
+          {Array.from({ length: DEFAULT_ITEMS_NUMBER }, (_, index) => (
+            <Tile key={String(index)}>
+              <ProductTileSkeleton tileIndex={index + 1} variant={variant} />
+            </Tile>
+          ))}
+        </Tiles>
+      </div>
+    </Section>
   ) : (
     <>{children}</>
   )

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -10,7 +10,6 @@ import IncentivesHeader from 'src/components/sections/Incentives/IncentivesHeade
 import IncentivesMock from 'src/components/sections/Incentives/incentivesMock'
 import ProductShelf from 'src/components/sections/ProductShelf'
 import ProductTiles from 'src/components/sections/ProductTiles'
-import ProductShelfSkeleton from 'src/components/skeletons/ProductShelfSkeleton'
 import ProductTilesSkeleton from 'src/components/skeletons/ProductTilesSkeleton'
 import { ITEMS_PER_SECTION } from 'src/constants'
 import { mark } from 'src/sdk/tests/mark'
@@ -80,13 +79,11 @@ function Page(props: Props) {
 
       <IncentivesHeader incentives={IncentivesMock} />
 
-      <Suspense fallback={<ProductShelfSkeleton loading />}>
-        <ProductShelf
-          first={ITEMS_PER_SECTION}
-          selectedFacets={[{ key: 'productClusterIds', value: '140' }]}
-          title="Most Wanted"
-        />
-      </Suspense>
+      <ProductShelf
+        first={ITEMS_PER_SECTION}
+        selectedFacets={[{ key: 'productClusterIds', value: '140' }]}
+        title="Most Wanted"
+      />
 
       <Suspense fallback={<ProductTilesSkeleton loading />}>
         <ProductTiles
@@ -102,13 +99,11 @@ function Page(props: Props) {
         actionLabel="Call to action"
       />
 
-      <Suspense fallback={<ProductShelfSkeleton loading />}>
-        <ProductShelf
-          first={ITEMS_PER_SECTION}
-          selectedFacets={[{ key: 'productClusterIds', value: '142' }]}
-          title="Deals & Promotions"
-        />
-      </Suspense>
+      <ProductShelf
+        first={ITEMS_PER_SECTION}
+        selectedFacets={[{ key: 'productClusterIds', value: '142' }]}
+        title="Deals & Promotions"
+      />
     </>
   )
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,14 +3,12 @@ import 'src/styles/pages/homepage.scss'
 import { useSession } from '@faststore/sdk'
 import { graphql } from 'gatsby'
 import { GatsbySeo, JsonLd } from 'gatsby-plugin-next-seo'
-import { Suspense } from 'react'
 import BannerText from 'src/components/sections/BannerText'
 import Hero from 'src/components/sections/Hero'
 import IncentivesHeader from 'src/components/sections/Incentives/IncentivesHeader'
 import IncentivesMock from 'src/components/sections/Incentives/incentivesMock'
 import ProductShelf from 'src/components/sections/ProductShelf'
 import ProductTiles from 'src/components/sections/ProductTiles'
-import ProductTilesSkeleton from 'src/components/skeletons/ProductTilesSkeleton'
 import { ITEMS_PER_SECTION } from 'src/constants'
 import { mark } from 'src/sdk/tests/mark'
 import type { PageProps } from 'gatsby'
@@ -85,13 +83,11 @@ function Page(props: Props) {
         title="Most Wanted"
       />
 
-      <Suspense fallback={<ProductTilesSkeleton loading />}>
-        <ProductTiles
-          first={3}
-          selectedFacets={[{ key: 'productClusterIds', value: '141' }]}
-          title="Just Arrived"
-        />
-      </Suspense>
+      <ProductTiles
+        first={3}
+        selectedFacets={[{ key: 'productClusterIds', value: '141' }]}
+        title="Just Arrived"
+      />
 
       <BannerText
         title="Receive our news and promotions in advance. Enjoy and get 10% off on your first purchase."

--- a/src/sdk/product/useProductsQuery.ts
+++ b/src/sdk/product/useProductsQuery.ts
@@ -83,7 +83,6 @@ export const useProductsQuery = (
     query,
     localizedVariables,
     {
-      fallbackData: null,
       suspense: true,
       ...options,
     }


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR changes the `ProductShelf` and `ProductTiles` sections to properly use `Suspense` to display its `Skeletons`.

## How does it work?

It wraps both components into a `Suspense` clause. The wrapping is made at the `index.tsx` file of these components. This way, we could remove the `Suspense` call from the homepage and the `Skeleton` call inside the component.

## How to test it?

Go to the preview link and reload the homepage. The skeletons at the `ProductShelf` and `ProductTiles` sections should appear in the proper place and without shifts.

## References
https://pt-br.reactjs.org/docs/concurrent-mode-suspense.html
https://sergiodxa.com/articles/swr/suspense/

## Checklist

<em>You may erase this after checking them all ;)</em>

**Changelog**
- [x] Added an entry in the `CHANGELOG.md` at the beginning of its due section. [The latest version should comes first](https://keepachangelog.com/en/1.0.0/#:~:text=The%20latest%20version%20comes%20first.).
- [x] Added the PR number with the PR link at the entry in the `CHANGELOG.md`. E.g., *New items in the `pull_request_template.md` ([#12](https://github.com/vtex-sites/gatsby.store/pull/12))*

**PR Description**
- [x] Added a label according to the PR goal - `Breaking change`, `Enhancement`, `Bug` or `Chore`.
- [x] Added the component, hook, or pathname in-between backticks (``) *- If applicable*. E.g., *`ComponentName` component*.
- [x] Identified the function or parameter in the PR *- If applicable*. E.g., *`useWindowDimensions` hook*.

**Documentation**
- [x] PR description
- [x] Added to/Updated the Storybook - *if applicable*.
- [x] For documentation changes, ping @ carolinamenezes, @ PedroAntunesCosta or @ Mariana-Caetano to review and update.
