### PR TITLE
Fix: scrollTo not working on Safari 15.4

### DIFF
--- a/src/components/ui/ImageGallery/ImageGallerySelector.tsx
+++ b/src/components/ui/ImageGallery/ImageGallerySelector.tsx
@@ -13,6 +13,8 @@ interface Props {
   currentImageIdx: number
 }
 
+const SCROLL_MARGIN_VALUE = 400
+
 const moveScroll = (container: HTMLDivElement | null, value: number) => {
   if (container) {
     if (container.scrollHeight > container.clientHeight) {
@@ -62,7 +64,7 @@ function ImageGallerySelector({ images, onSelect, currentImageIdx }: Props) {
         <IconButton
           aria-label="backward slide image selector"
           icon={<Icon name="ArrowLeft" width={24} height={24} />}
-          onClick={() => moveScroll(elementsRef.current, -200)}
+          onClick={() => moveScroll(elementsRef.current, -SCROLL_MARGIN_VALUE)}
         />
       )}
       <div data-fs-image-gallery-selector-elements ref={elementsRef}>
@@ -102,7 +104,7 @@ function ImageGallerySelector({ images, onSelect, currentImageIdx }: Props) {
         <IconButton
           aria-label="forward slide image selector"
           icon={<Icon name="ArrowLeft" width={24} height={24} />}
-          onClick={() => moveScroll(elementsRef.current, +200)}
+          onClick={() => moveScroll(elementsRef.current, +SCROLL_MARGIN_VALUE)}
         />
       )}
     </section>

--- a/src/components/ui/ImageGallery/ImageGallerySelector.tsx
+++ b/src/components/ui/ImageGallery/ImageGallerySelector.tsx
@@ -16,6 +16,12 @@ interface Props {
 const moveScroll = (container: HTMLDivElement | null, value: number) => {
   if (container) {
     if (container.scrollHeight > container.clientHeight) {
+      // TODO: Temporary workaround for scroll-behavior with scrollTop – Safari 15.4) https://developer.apple.com/forums/thread/703294
+      container.style.overflow = 'auto'
+      window.requestAnimationFrame(() =>
+        container.scrollTo({ top: value, behavior: 'smooth' })
+      )
+      setTimeout(() => (container.style.overflow = 'hidden'), 2000)
       container.scrollTop += value
     } else {
       container.scrollLeft += value

--- a/src/components/ui/ImageGallery/image-gallery-selector.module.scss
+++ b/src/components/ui/ImageGallery/image-gallery-selector.module.scss
@@ -66,6 +66,10 @@
     overflow-x: auto;
     scroll-behavior: smooth;
 
+    &::-webkit-scrollbar {
+      display: none;
+    }
+
     > [data-store-button] {
       flex-shrink: 0;
       width: rem(56px);


### PR DESCRIPTION
Ported from https://github.com/vtex-sites/nextjs.store/pull/132
## What's the purpose of this pull request?
This PR attempts to fix two issues:
1.  `scroll-behavior` not working on Safari 15.4 when using `scrollTop`: https://developer.apple.com/forums/thread/703294
![not-scrolling](http://g.recordit.co/FfIeoY9Ail.gif)
2. Not scrolling to the last image position.
![last-image-missing](http://g.recordit.co/6VBDtpqM0v.gif)

## How does it work?

1. This issue could also be fixed g the `scroll-behavior: smooth` property. But after aligning with the design team, we favor the workaround approach with a smooth's effect. We should keep an eye out for safari updates and remove them when the native approach is available.

2. Increased a little the threshold, but it won't work for all the cases. It needs further improvements and should be tackled at another moment.

## How to test it?

1. Open this [preview link](https://sfj-d31738a--nextjs.preview.vtex.app/apple-magic-mouse-99988212/p) on Safari.
2. Click on the Down Arrow button, scroll should work, and you'll see more images' thumbnails. 


## References

- https://developer.apple.com/forums/thread/703294
- https://github.com/WebKit/WebKit/pull/1387
- https://developer.apple.com/documentation/safari-release-notes
- https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-scrollbar

**Changelog**
- [ ] Added an entry in the `CHANGELOG.md` at the beginning of its due section. [The latest version should comes first](https://keepachangelog.com/en/1.0.0/#:~:text=The%20latest%20version%20comes%20first.).
- [ ] Added the PR number with the PR link at the entry in the `CHANGELOG.md`. E.g., *New items in the `pull_request_template.md` ([#12](https://github.com/vtex-sites/gatsby.store/pull/12))*

**PR Description**
- [ ] Added a label according to the PR goal - `Breaking change`, `Enhancement`, `Bug` or `Chore`.
- [ ] Added the component, hook, or pathname in-between backticks (``) *- If applicable*. E.g., *`ComponentName` component*.
- [ ] Identified the function or parameter in the PR *- If applicable*. E.g., *`useWindowDimensions` hook*.

**Documentation**
- [ ] PR description
- [ ] Added to/Updated the Storybook - *if applicable*.
- [ ] For documentation changes, ping @ carolinamenezes, @ PedroAntunesCosta or @ Mariana-Caetano to review and update.
