### PR TITLE
fix: SonarQube warnings/error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Sonarqube warning about unnecessary parameter ([#145](https://github.com/vtex-sites/gatsby.store/pull/145))
 - `ImageGallerySelector` scroll that isn't working on Safari ([##121](https://github.com/vtex-sites/gatsby.store/pull/121))
 - Some console errors when running the storybook ([#115](https://github.com/vtex-sites/gatsby.store/pull/115))
 - Status code when error occurs (404/500) ([#108](https://github.com/vtex-sites/gatsby.store/pull/108))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Sonarqube warning about unnecessary parameter ([#145](https://github.com/vtex-sites/gatsby.store/pull/145))
+- SonarQube warnings and error ([#145](https://github.com/vtex-sites/gatsby.store/pull/145))
 - `ImageGallerySelector` scroll that isn't working on Safari ([##121](https://github.com/vtex-sites/gatsby.store/pull/121))
 - Some console errors when running the storybook ([#115](https://github.com/vtex-sites/gatsby.store/pull/115))
 - Status code when error occurs (404/500) ([#108](https://github.com/vtex-sites/gatsby.store/pull/108))

--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -14,7 +14,7 @@ const RegionModal = lazy(
   () => import('src/components/regionalization/RegionalizationModal')
 )
 
-function Layout({ children }: PropsWithChildren<unknown>) {
+function Layout({ children }: PropsWithChildren) {
   const { cart: displayCart, modal: displayModal } = useUI()
 
   return (

--- a/src/components/ui/Modal/Modal.tsx
+++ b/src/components/ui/Modal/Modal.tsx
@@ -12,8 +12,10 @@ export type ModalChildrenProps = {
   fadeIn: () => void
 }
 
+type ModalChildrenFunction = (props: ModalChildrenProps) => ReactNode
+
 export type ModalProps = Omit<UIModalProps, 'isOpen' | 'children'> & {
-  children: (props: ModalChildrenProps) => ReactNode | ReactNode
+  children: ModalChildrenFunction | ReactNode
 }
 
 function Modal({ className, children, ...props }: ModalProps) {

--- a/src/sdk/tests/index.tsx
+++ b/src/sdk/tests/index.tsx
@@ -9,7 +9,7 @@ import type { PropsWithChildren } from 'react'
 
 let renders = 0
 
-function TestProvider({ children }: PropsWithChildren<unknown>) {
+function TestProvider({ children }: PropsWithChildren) {
   const [id, setId] = useState('')
 
   useEffect(() => {

--- a/src/sdk/ui/Provider.tsx
+++ b/src/sdk/ui/Provider.tsx
@@ -107,7 +107,7 @@ interface Context extends State {
 
 const UIContext = createContext<Context | undefined>(undefined)
 
-function UIProvider({ children }: PropsWithChildren<unknown>) {
+function UIProvider({ children }: PropsWithChildren) {
   const [ui, dispatch] = useReducer(reducer, undefined, initializer)
 
   const callbacks = useMemo(


### PR DESCRIPTION
## What's the purpose of this pull request?

ported from https://github.com/vtex-sites/nextjs.store/pull/127

<img width="637" alt="image" src="https://user-images.githubusercontent.com/1753396/173955671-d3372499-71bf-4e64-985c-6642832f1273.png">

But also fixes:

<img width="588" alt="Screen Shot 2022-07-11 at 16 08 44" src="https://user-images.githubusercontent.com/11325562/178339872-3d063ef9-d836-4520-b415-4dea5beea49c.png">

<img width="489" alt="Screen Shot 2022-07-11 at 16 08 01" src="https://user-images.githubusercontent.com/11325562/178339767-65387f77-1239-4660-8d55-fb6d27b7c410.png">


## Checklist

<em>You may erase this after checking them all ;)</em>

**Changelog**
- [x] Added an entry in the `CHANGELOG.md` at the beginning of its due section. [The latest version should comes first](https://keepachangelog.com/en/1.0.0/#:~:text=The%20latest%20version%20comes%20first.).
- [x] Added the PR number with the PR link at the entry in the `CHANGELOG.md`. E.g., *New items in the `pull_request_template.md` ([#12](https://github.com/vtex-sites/gatsby.store/pull/12))*

**PR Description**
- [x] Added a label according to the PR goal - `Breaking change`, `Enhancement`, `Bug` or `Chore`.
- [x] Added the component, hook, or pathname in-between backticks (``) *- If applicable*. E.g., *`ComponentName` component*.
- [x] Identified the function or parameter in the PR *- If applicable*. E.g., *`useWindowDimensions` hook*.

**Documentation**
- [x] PR description
- [x] Added to/Updated the Storybook - *if applicable*.
- [ ] For documentation changes, ping @ carolinamenezes, @ PedroAntunesCosta or @ Mariana-Caetano to review and update.
