### PR TITLE
chore: Stabilize a flaky PLP test

### DIFF
--- a/cypress/integration/plp.test.js
+++ b/cypress/integration/plp.test.js
@@ -210,16 +210,13 @@ describe('Infinite Scroll pagination', () => {
     cy.visit(pages.collection, options)
     cy.waitForHydration()
 
-    cy.getById('show-more')
-      .should('exist')
-      .click()
+    cy.getById('show-more').should('exist').click()
 
-      .getById('total-product-count')
-      .scrollIntoView({ duration: 1000 })
+    cy.scrollTo('top')
       .location('search')
       .should('match', /page=0$/)
 
-      .get('[data-testid=product-gallery] [data-testid=store-product-card]')
+    cy.get('[data-testid=product-gallery] [data-testid=store-product-card]')
       .last()
       .scrollIntoView({ duration: 1000 })
       .location('search')


### PR DESCRIPTION
## What's the purpose of this pull request?

If you look at the Integration Test runs for the last merge commits on [main](https://github.com/vtex-sites/nextjs.store/commits/main) you'll notice [many](https://github.com/vtex-sites/nextjs.store/runs/7362634973) [of](https://github.com/vtex-sites/nextjs.store/runs/7283910556) [them](https://github.com/vtex-sites/nextjs.store/runs/7181122807) [failed](https://github.com/vtex-sites/nextjs.store/runs/7215635303) the specific test **"plp.test.js/Infinite Scroll pagination -- Changes the page being viewed on scroll"**.

![Flaky test](https://camo.githubusercontent.com/b8fb88bdb48620e1f6967f50b3d17fdb6d7cc9573681e09461dd8f3c867d080e/68747470733a2f2f6661737473746f72652d746573742d6173736574732e73332e616d617a6f6e6177732e636f6d2f3261333966653130623138323766313133376234393164333861323832646434)

This PR attempts to tweak the test to add more stability so it doesn't fail frequently.

## How does it work?

Instead of scrolling to the PLP results counter element, we now scroll to the top of the page. The reason we scroll is because we're testing that the pagination's page query string is updated from `?page=1` to `?page=0`. Scrolling higher than before gives us more stability to trigger this query string change.

## How to test it?

Run `yarn test` in development and make sure this specific test is still passing. 

I have pushed 4x empty commits to trigger the Integration Test and this test hasn't failed any time (no manual re-runs). Hopefully this means it's more stable than before. 