### PR TITLE
chore: Update PR template to reflect recent changelog changes 

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -20,9 +20,9 @@
 
 <em>You may erase this after checking them all ;)</em>
 
-**Changelog**
-- [ ] Added an entry in the `CHANGELOG.md` at the beginning of its due section. [The latest version should comes first](https://keepachangelog.com/en/1.0.0/#:~:text=The%20latest%20version%20comes%20first.).
-- [ ] Added the PR number with the PR link at the entry in the `CHANGELOG.md`. E.g., *New items in the `pull_request_template.md` ([#12](https://github.com/vtex-sites/gatsby.store/pull/12))*
+**PR Title and Commit Messages**
+- [ ] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification
+- [ ] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification
 
 **PR Description**
 - [ ] Added a label according to the PR goal - `Breaking change`, `Enhancement`, `Bug` or `Chore`.


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR updates the PR template to reflect recent changes in the changelog.

## How does it work?

I've added checklists regarding PR titles and commit messages and removed old ones regarding changelog entries
