### PR TITLE
Feat: adds tokens to `PriceRange`

### DIFF
--- a/src/components/ui/InputText/input-text.scss
+++ b/src/components/ui/InputText/input-text.scss
@@ -28,8 +28,9 @@
 
   // Message
   --fs-input-message-size          : var(--fs-text-size-legend);
-  --fs-input-message-line-height   : 1.5;
+  --fs-input-message-line-height   : 1.1;
   --fs-input-message-error-color   : var(--fs-color-danger-text);
+  --fs-input-message-margin-top    : var(--fs-spacing-0);
 
   // Label
   --fs-input-label-padding         : 0 var(--fs-spacing-2);
@@ -115,7 +116,7 @@
 }
 
 [data-fs-input-text-message] {
-  margin-top: rem(2px);
+  margin-top: var(--fs-input-message-margin-top);
   font-size: var(--fs-input-message-size);
   line-height: var(--fs-input-message-line-height);
 }

--- a/src/components/ui/PriceRange/PriceRange.stories.mdx
+++ b/src/components/ui/PriceRange/PriceRange.stories.mdx
@@ -15,6 +15,30 @@ import {
   argTypes={{
     min: { control: { disable: true } },
     max: { control: { disable: true } },
+    testId: {
+      table: {
+        disable: true,
+      },
+    },
+    className: {
+      table: {
+        disable: true,
+      },
+    },
+    onChange: {
+      table: {
+        disable: true,
+      },
+    },
+    variant: {
+      table: {
+        disable: true,
+      },
+    },
+    step: {
+      control: 'number',
+      table: { type: 'number', summary: 10 },
+    },
   }}
   component={PriceRange}
 />
@@ -22,11 +46,11 @@ import {
 export const defaultArgs = {
   min: {
     absolute: 0,
-    selected: 10,
+    selected: 0,
   },
   max: {
-    selected: 90,
-    absolute: 100,
+    absolute: 12400,
+    selected: 12400,
   },
 }
 
@@ -48,7 +72,7 @@ PriceRange allows you to implement filters on PLP so users have a high control o
 
 ## Overview
 
-The `PriceRange` component uses [FastStore UI PriceRange](https://www.faststore.dev/reference/ui/molecules/PriceRange) as base.
+The `PriceRange` component uses [FastStore UI Price Range](https://www.faststore.dev/reference/ui/molecules/PriceRange) as base.
 
 ---
 
@@ -65,41 +89,107 @@ The `PriceRange` component uses [FastStore UI PriceRange](https://www.faststore.
 <ArgsTable story="overview-default" />
 
 <TokenTable>
-  <TokenRow token="--fs-price-range-height" value=".5rem" />
+  <TokenRow token="--fs-price-range-height" value="var(--fs-spacing-2)" />
   <TokenRow
     token="--fs-price-range-border-radius"
-    value="var(--fs-border-radius)"
+    value="var(--fs-border-radius-pill)"
+  />
+  <TokenRow
+    token="--fs-price-range-margin-bottom"
+    value="var(--fs-spacing-3)"
   />
   <TokenDivider />
   <TokenRow
-    token="--fs-price-range-bkg-color"
-    value="var(--fs-color-primary-bkg-light)"
+    token="--fs-price-range-transition-function"
+    value="var(--fs-transition-function)"
+  />
+  <TokenRow
+    token="--fs-price-range-transition-property"
+    value="varvar(--fs-transition-property)"
+  />
+  <TokenRow
+    token="--fs-price-range-transition-timing"
+    value="var(--fs-transition-timing)"
+  />
+</TokenTable>
+
+---
+
+## Nested Elements
+
+### Slider
+
+<TokenTable>
+  <TokenRow
+    token="--fs-price-range-slider-bkg-color"
+    value="var(--fs-color-neutral-bkg)"
     isColor
   />
   <TokenRow
-    token="--fs-price-range-range-bkg-color"
-    value="var(--fs-color-primary-bkg)"
+    token="--fs-price-range-slider-selection-bkg-color"
+    value="var(--fs-color-primary-bkg-light-active)"
     isColor
   />
+</TokenTable>
+
+### Value Label
+
+<TokenTable>
+  <TokenRow
+    token="--fs-price-range-value-label-bottom"
+    value="var(--fs-spacing-3)"
+  />
+  <TokenRow
+    token="--fs-price-range-value-label-bkg-color"
+    value="var(--fs-color-body-bkg)"
+    isColor
+  />
+</TokenTable>
+
+### Absolute Values
+
+<TokenTable>
+  <TokenRow
+    token="--fs-price-range-absolute-values-text-color"
+    value="var(--fs-color-disabled-text)"
+    isColor
+  />
+</TokenTable>
+
+### Thumb
+
+<TokenTable>
+  <TokenRow token="--fs-price-range-thumb-size" value="var(--fs-spacing-4)" />
   <TokenDivider />
   <TokenRow
     token="--fs-price-range-thumb-bkg-color"
-    value="var(--fs-color-tertiary-bkg-light)"
+    value="var(--fs-color-primary-bkg)"
     isColor
   />
   <TokenRow
-    token="--fs-price-range-thumb-radius"
+    token="--fs-price-range-thumb-bkg-color-hover"
+    value="var(--fs-color-primary-bkg-hover)"
+    isColor
+  />
+  <TokenDivider />
+  <TokenRow
+    token="--fs-price-range-thumb-border-radius"
     value="var(--fs-border-radius-circle)"
   />
-  <TokenRow token="--fs-price-range-thumb-size" value="1rem" />
   <TokenRow
     token="--fs-price-range-thumb-border-color"
-    value="var(--fs-border-color)"
+    value="var(--fs-price-range-thumb-bkg-color)"
+    globalValue="var(--fs-color-primary-bkg)"
+    isColor
+  />
+  <TokenRow
+    token="--fs-price-range-thumb-border-color-hover"
+    value="var(--fs-price-range-thumb-bkg-color-hover)"
+    globalValue="var(--fs-color-primary-bkg-hover)"
     isColor
   />
   <TokenRow
     token="--fs-price-range-thumb-border-width"
     value="var(--fs-border-width)"
-    isColor
   />
 </TokenTable>

--- a/src/components/ui/PriceRange/PriceRange.tsx
+++ b/src/components/ui/PriceRange/PriceRange.tsx
@@ -1,21 +1,136 @@
+import { useState, useRef } from 'react'
 import { PriceRange as UIPriceRange } from '@faststore/ui'
-import { usePriceFormatter } from 'src/sdk/product/useFormattedPrice'
 import type { PriceRangeProps } from '@faststore/ui'
+import {
+  usePriceFormatter,
+  useFormattedPrice,
+} from 'src/sdk/product/useFormattedPrice'
 
 import styles from './price-range.module.scss'
+import InputText from '../InputText'
 
-type Props = Omit<PriceRangeProps, 'formatter'>
+type Props = Omit<
+  PriceRangeProps,
+  'formatter' | 'minValueLabelComponent' | 'maxValueLabelComponent'
+>
 
-function PriceRange(props: Props) {
-  const formatter = usePriceFormatter()
+function PriceRange({ min, max, onEnd, step = 10, ...otherProps }: Props) {
+  const formatter = usePriceFormatter({ decimals: false })
+  const minAbsoluteFormatted = useFormattedPrice(Math.round(min.absolute))
+  const maxAbsoluteFormatted = useFormattedPrice(Math.ceil(max.absolute))
+
+  const inputMinRef = useRef<HTMLInputElement>(null)
+  const inputMaxRef = useRef<HTMLInputElement>(null)
+  const priceRangeRef = useRef<{
+    setPriceRangeValues: (values: { min: number; max: number }) => void
+  }>()
+
+  const [inputMinError, setInputMinError] = useState<string>()
+  const [inputMaxError, setInputMaxError] = useState<string>()
+  const [priceRange, setPriceRange] = useState<{ min: number; max: number }>({
+    min: Math.round(min.selected),
+    max: Math.ceil(max.selected),
+  })
+
+  function onChangePriceRange(value: { min: number; max: number }) {
+    setInputMinError(undefined)
+    setInputMaxError(undefined)
+    setPriceRange({ min: value.min, max: value.max })
+
+    if (inputMinRef.current?.value) {
+      inputMinRef.current.value = String(value.min)
+    }
+
+    if (inputMaxRef.current?.value) {
+      inputMaxRef.current.value = String(value.max)
+    }
+  }
+
+  function onChangeInputMin(value: string) {
+    setInputMinError(undefined)
+
+    if (Number(value) < min.absolute) {
+      return
+    }
+
+    if (Number(value) > priceRange.max) {
+      setInputMinError(`Min price can't be greater than max`)
+    }
+
+    setPriceRange({ ...priceRange, min: Number(value) })
+    priceRangeRef.current?.setPriceRangeValues({
+      ...priceRange,
+      min: Number(value),
+    })
+  }
+
+  function onChangeInputMax(value: string) {
+    setInputMaxError(undefined)
+
+    if (Number(value) > max.absolute) {
+      return
+    }
+
+    if (Number(value) < priceRange.min) {
+      setInputMaxError(`Max price can't be smaller than min`)
+    }
+
+    setPriceRange({ ...priceRange, max: Number(value) })
+    priceRangeRef.current?.setPriceRangeValues({
+      ...priceRange,
+      max: Number(value),
+    })
+  }
 
   return (
-    <UIPriceRange
-      data-fs-price-range
-      className={styles.fsPriceRange}
-      formatter={formatter}
-      {...props}
-    />
+    <div className={styles.fsPriceRange} data-fs-price-range>
+      <div data-fs-price-range-absolute-values>
+        <span>{minAbsoluteFormatted}</span>
+        <span>{maxAbsoluteFormatted}</span>
+      </div>
+      <UIPriceRange
+        ref={priceRangeRef}
+        min={min}
+        max={max}
+        formatter={formatter}
+        className={styles.fsPriceRange}
+        onEnd={(value) => {
+          onEnd?.(value)
+          onChangePriceRange(value)
+        }}
+        {...otherProps}
+      />
+      <div data-fs-price-range-inputs>
+        <InputText
+          id="price-range-min"
+          step={step}
+          label="Min"
+          type="number"
+          inputMode="numeric"
+          error={inputMinError}
+          inputRef={inputMinRef}
+          min={Math.round(min.absolute)}
+          max={Math.ceil(priceRange.max)}
+          value={Math.round(priceRange.min)}
+          onChange={(e) => onChangeInputMin(e.target.value)}
+          onBlur={() => !inputMinError && onEnd?.(priceRange)}
+        />
+        <InputText
+          id="price-range-max"
+          label="Max"
+          step={step}
+          type="number"
+          inputMode="numeric"
+          error={inputMaxError}
+          inputRef={inputMaxRef}
+          max={Math.ceil(max.absolute)}
+          min={Math.round(priceRange.min)}
+          value={Math.ceil(priceRange.max)}
+          onChange={(e) => onChangeInputMax(e.target.value)}
+          onBlur={() => !inputMaxError && onEnd?.(priceRange)}
+        />
+      </div>
+    </div>
   )
 }
 

--- a/src/components/ui/PriceRange/price-range.module.scss
+++ b/src/components/ui/PriceRange/price-range.module.scss
@@ -6,81 +6,131 @@
   // --------------------------------------------------------
 
   // Default properties
-  --fs-price-range-slider-height: .5rem;
-  --fs-price-range-slider-border-radius: var(--fs-border-radius);
+  --fs-price-range-height                     : var(--fs-spacing-2);
+  --fs-price-range-border-radius              : var(--fs-border-radius-pill);
+  --fs-price-range-margin-bottom              : var(--fs-spacing-3);
+
+  --fs-price-range-transition-function        : var(--fs-transition-function);
+  --fs-price-range-transition-property        : var(--fs-transition-property);
+  --fs-price-range-transition-timing          : var(--fs-transition-timing);
 
   // Slider
-  --fs-price-range-slider-bkg-color: var(--fs-color-primary-bkg-light);
-  --fs-price-range-slider-range-bkg-color: var(--fs-color-primary-bkg);
+  --fs-price-range-slider-bkg-color           : var(--fs-color-neutral-bkg);
+  --fs-price-range-slider-selection-bkg-color : var(--fs-color-primary-bkg-light-active);
+
+  // Value Label
+  --fs-price-range-value-label-bottom         : var(--fs-spacing-3);
+  --fs-price-range-value-label-bkg-color      : var(--fs-color-body-bkg);
+
+  // Absolute Values
+  --fs-price-range-absolute-values-text-color : var(--fs-color-disabled-text);
 
   // Thumb
-  --fs-price-range-slider-thumb-bkg-color: var(--fs-color-tertiary-bkg-light);
-  --fs-price-range-slider-thumb-radius: var(--fs-border-radius-circle);
-  --fs-price-range-slider-thumb-size: 1rem;
-  --fs-price-range-slider-thumb-border-color: var(--fs-border-color);
-  --fs-price-range-slider-thumb-border-width: var(--fs-border-width);
+  --fs-price-range-thumb-size                 : var(--fs-spacing-4);
+  --fs-price-range-thumb-bkg-color            : var(--fs-color-primary-bkg);
+  --fs-price-range-thumb-bkg-color-hover      : var(--fs-color-primary-bkg-hover);
+  --fs-price-range-thumb-border-radius        : var(--fs-border-radius-circle);
+  --fs-price-range-thumb-border-color         : var(--fs-price-range-thumb-bkg-color);
+  --fs-price-range-thumb-border-color-hover   : var(--fs-price-range-thumb-bkg-color-hover);
+  --fs-price-range-thumb-border-width         : var(--fs-border-width);
 
   // --------------------------------------------------------
   // Structural Styles
   // --------------------------------------------------------
+
   [data-store-slider] {
     position: relative;
     width: 100%;
-    height: var(--fs-price-range-slider-height);
+    height: var(--fs-price-range-height);
+    margin-bottom: var(--fs-price-range-margin-bottom);
     background-color: var(--fs-price-range-slider-bkg-color);
-    border-radius: var(--fs-price-range-slider-border-radius);
+    border-radius: var(--fs-price-range-border-radius);
   }
 
   [data-slider-range] {
     position: absolute;
-    height: var(--fs-price-range-slider-height);
-    background-color: var(--fs-price-range-slider-range-bkg-color);
-    border-radius: var(--fs-price-range-slider-border-radius);
+    height: var(--fs-price-range-height);
+    background-color: var(--fs-price-range-slider-selection-bkg-color);
+    border-radius: var(--fs-price-range-border-radius);
   }
 
-  // TODO: Figure out a way for not repeating all styles for both
-  // webkit and and mozilla
+  [data-price-range-value-label="min"],
+  [data-price-range-value-label="max"] {
+    bottom: var(--fs-price-range-value-label-bottom);
+    padding: var(--fs-spacing-1);
+    background-color: var(--fs-price-range-value-label-bkg-color);
+    opacity: 0;
+    transition: opacity var(--fs-price-range-transition-timing) var(--fs-price-range-transition-function);
 
-  /* Thumb styles for Webkit based browsers (Chrome, Edge) */
+    &:hover {
+      opacity: 1;
+    }
+  }
+
+  [data-price-range-value-label="min"] {
+    text-align: left;
+    transform: translateX(-1rem);
+  }
+
+  [data-price-range-value-label="max"] {
+    text-align: right;
+    transform: translateX(calc(-100% + 1.25rem));
+  }
+
+  // Thumb styles for Webkit based browsers (Chrome, Edge)
   [data-slider-thumb],
   [data-slider-thumb]::-webkit-slider-thumb {
-    width: var(--fs-price-range-slider-thumb-size);
-    height: var(--fs-price-range-slider-thumb-size);
+    width: var(--fs-price-range-thumb-size);
+    height: var(--fs-price-range-thumb-size);
     pointer-events: auto;
     cursor: col-resize;
-    background-color: var(--fs-price-range-slider-thumb-bkg-color);
+    background-color: var(--fs-price-range-thumb-bkg-color);
     border: var(--fs-price-range-thumb-border-width) solid var(--fs-price-range-thumb-border-color);
-    border-radius: var(--fs-price-range-slider-thumb-radius);
-    appearance: none;
+    border-radius: var(--fs-price-range-thumb-border-radius);
     -webkit-tap-highlight-color: transparent;
+    appearance: none;
+    transition: var(--fs-price-range-transition-property) var(--fs-price-range-transition-timing) var(--fs-price-range-transition-function);
+
+    &:hover {
+      background-color: var(--fs-price-range-thumb-bkg-color-hover);
+      border-color: var(--fs-price-range-thumb-border-color-hover);
+    }
   }
 
-  /* Thumb styles for Mozilla */
+  // Thumb styles for Mozilla
   [data-slider-thumb]::-moz-range-thumb {
-    width: var(--fs-price-range-slider-thumb-size);
-    height: var(--fs-price-range-slider-thumb-size);
+    width: var(--fs-price-range-thumb-size);
+    height: var(--fs-price-range-thumb-size);
     pointer-events: auto;
     cursor: col-resize;
-    background-color: var(--fs-price-range-slider-thumb-bkg-color);
+    background-color: var(--fs-price-range-thumb-bkg-color);
     border: var(--fs-price-range-thumb-border-width) solid var(--fs-price-range-thumb-border-color);
-    border-radius: var(--fs-price-range-slider-thumb-radius);
+    border-radius: var(--fs-price-range-thumb-radius);
   }
 
   [data-slider-thumb] {
     position: absolute;
     width: inherit;
     height: 0;
-    margin: calc(var(--fs-price-range-slider-height) / 2) 0;
+    margin: calc(var(--fs-price-range-height) / 2) 0;
     pointer-events: none;
     border: none;
   }
 
   [data-slider-thumb="left"] {
     z-index: 1;
+
+    &:hover + [data-price-range-value-label="min"] {
+      opacity: 1;
+    }
   }
 
   [data-slider-thumb="right"] {
     z-index: 2;
+
+    &:hover + [data-price-range-value-label="max"] {
+      opacity: 1;
+    }
   }
 
   [data-price-range-values] {
@@ -88,5 +138,41 @@
     justify-content: space-between;
     margin-top: var(--fs-spacing-3);
     margin-bottom: var(--fs-spacing-3);
+  }
+
+  [data-fs-price-range-inputs] {
+    display: flex;
+
+    [data-fs-input-text] {
+      width: 50%;
+
+      input:hover,
+      input:focus-visible,
+      input:focus {
+        z-index: 1;
+        + label { z-index: 1; }
+      }
+
+      &:first-of-type {
+        margin-right: -1px;
+
+        input {
+          border-top-right-radius: 0;
+          border-bottom-right-radius: 0;
+        }
+      }
+
+      &:last-of-type input {
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
+      }
+    }
+  }
+
+  [data-fs-price-range-absolute-values] {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: var(--fs-spacing-2);
+    color: var(--fs-price-range-absolute-values-text-color);
   }
 }

--- a/src/sdk/product/useFormattedPrice.ts
+++ b/src/sdk/product/useFormattedPrice.ts
@@ -1,7 +1,11 @@
 import { useCallback, useMemo } from 'react'
 import { useSession } from '@faststore/sdk'
 
-export const usePriceFormatter = () => {
+interface PriceFormatterOptions {
+  decimals?: boolean
+}
+
+export const usePriceFormatter = ({ decimals }: PriceFormatterOptions = {}) => {
   const { currency, locale } = useSession()
 
   return useCallback(
@@ -9,8 +13,9 @@ export const usePriceFormatter = () => {
       Intl.NumberFormat(locale, {
         style: 'currency',
         currency: currency.code,
+        minimumFractionDigits: decimals ? 2 : 0,
       }).format(price),
-    [currency.code, locale]
+    [currency.code, locale, decimals]
   )
 }
 

--- a/src/styles/global/tokens.scss
+++ b/src/styles/global/tokens.scss
@@ -14,7 +14,7 @@ body {
   // Tone values must range from lightest to darkest.
   // `0` is more suitable for backgrounds, and `4` for texts.
   --fs-color-main-0                    : #f1f2f3;
-  --fs-color-main-1                    : #e3e6e8;
+  --fs-color-main-1                    : #dbdbdb;
   --fs-color-main-2                    : #00419e;
   --fs-color-main-3                    : #002c71;
   --fs-color-main-4                    : #002155;


### PR DESCRIPTION
## What's the purpose of this pull request?
> Ported from `next.store` repo: [Feat: adds tokens to PriceRange #146](https://github.com/vtex-sites/nextjs.store/pull/146)

This PR applies the new [Theming structure](https://github.com/vtex-sites/base.store/pull/407) to `PriceRange`: new scoped tokens linked to global ones.

## How does it work?
This PR uses local variables to parameterize the `PriceRange` properties, then connects these scoped tokens to the global ones.

Tokens list can be visualized in the [Storybook](https://gatsby-store-storybook-git-feat-theming-price-4e6ef5-faststore.vercel.app/?path=/docs/molecules-pricerange--overview-default).

## How to test it?
- The `PriceRange` component and its related components should look just as it was before these changes.
- You can check the [story on Storybook](https://gatsby-store-storybook-git-feat-theming-price-4e6ef5-faststore.vercel.app/?path=/docs/molecules-pricerange--overview-default) and the component being used on PLP.

<img width="435" alt="image" src="https://user-images.githubusercontent.com/11613011/181353196-2edd4de6-5aa8-4274-9beb-847344160680.png">


## Checklist

**PR Description**
- [x] Added a label according to the PR goal - `Breaking change`, `Enhancement`, `Bug` or `Chore`.
- [x] Added the component, hook, or pathname in-between backticks (``) *- If applicable*. E.g., *`ComponentName` component*.

**Documentation**
- [x] PR description
- [x] Added to/Updated the Storybook - *if applicable*.


