### PR TITLE
fix: Display `SearchDropdown` correctly

### DIFF
--- a/.storybook/storybook.css
+++ b/.storybook/storybook.css
@@ -521,3 +521,10 @@ header.sbdocs-hero + .sbdocs-callout {
   flex-direction: column;
   width: 49%;
 }
+
+/* Navlinks - workaround to display on stories */
+/* stylelint-disable-next-line selector-id-pattern */
+#story--organisms-navbar-navlinks--overview-default {
+  position: relative;
+  z-index: 0;
+}

--- a/src/components/common/Navbar/navlinks.module.scss
+++ b/src/components/common/Navbar/navlinks.module.scss
@@ -34,7 +34,7 @@
   // --------------------------------------------------------
 
   position: relative;
-  z-index: var(--fs-z-index-default);
+  z-index: var(--fs-z-index-below);
   background-color: var(--fs-navlinks-bkg-color);
   transition: var(--fs-navlinks-transition-property) var(--fs-navlinks-transition-timing) var(--fs-navlinks-transition-function);
 


### PR DESCRIPTION
Ported from https://github.com/vtex-sites/nextjs.store/pull/212

## What's the purpose of this pull request?

- Attempts to fix `SearchDropdown` displaying below navlinks
- Follow-up https://github.com/vtex-sites/nextjs.store/pull/191#pullrequestreview-1061668003

## How does it work?

Changes back `z-index: var(--fs-z-index-below)`

|Current|Fixed|
|-|-|
|<img width="1154" alt="image" src="https://user-images.githubusercontent.com/3356699/185451624-b40bd241-147b-484e-a5fe-dae9ad8d2ce6.png">|<img width="1423" alt="image" src="https://user-images.githubusercontent.com/3356699/185452126-531a5962-849d-4434-bbeb-8a31e241545b.png">|

## How to test it?

- Check on the [preview](https://preview-212--nextjs.preview.vtex.app) if the search dropdown is being displayed correctly.
- Also verify if [navlinks](https://nextjs-store-storybook-git-fix-navlink-z-index-faststore.vercel.app/?path=/docs/organisms-navbar-navlinks--overview-default) is appearing on the stories.
<img width="1192" alt="image" src="https://user-images.githubusercontent.com/3356699/185616433-7032654c-272e-4dac-af1c-9ca5bb27a5be.png">


## References

<em>Spread the knowledge: is this any content you used to create this PR that is worth sharing?</em>

<em>Extra tip: add references to related issues or mention people important to this PR may be good for the documentation and reviewing process</em>

## Checklist

<em>You may erase this after checking them all ;)</em>

**PR Title and Commit Messages**
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification
- [x] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification

**PR Description**
- [x] Added a label according to the PR goal - `Breaking change`, `Enhancement`, `Bug` or `Chore`.
- [x] Added the component, hook, or pathname in-between backticks (``) *- If applicable*. E.g., *`ComponentName` component*.
- [x] Identified the function or parameter in the PR *- If applicable*. E.g., *`useWindowDimensions` hook*.

**Documentation**
- [x] PR description
- [x] Added to/Updated the Storybook - *if applicable*.
- [ ] For documentation changes, ping @ carolinamenezes, @ PedroAntunesCosta or @ Mariana-Caetano to review and update.
