### PR TITLE
fix: Fix cms config

### DIFF
--- a/cms/sections.json
+++ b/cms/sections.json
@@ -66,6 +66,18 @@
         "actionLabel": {
           "type": "string",
           "title": "Action label"
+        },
+        "colorVariant": {
+          "type": "string",
+          "title": "Color Variant",
+          "enumNames": ["Main", "Light", "Accent"],
+          "enum": ["main", "light", "accent"]
+        },
+        "variant": {
+          "type": "string",
+          "title": "Variant",
+          "enumNames": ["Primary", "Secondary"],
+          "enum": ["primary", "secondary"]
         }
       }
     }
@@ -110,16 +122,17 @@
     "schema": {
       "title": "Incentives Header",
       "description": "Add Incentives to your shopper",
-      "required": ["firstLineText", "icon"],
       "type": "object",
       "properties": {
         "incentives": {
+          "title": "Incentives",
           "type": "array",
           "minItems": 3,
           "maxItems": 5,
           "items": {
             "title": "Incentive",
             "type": "object",
+            "required": ["title", "firstLineText", "icon"],
             "properties": {
               "title": {
                 "type": "string",


### PR DESCRIPTION
Signed-off-by: Arthur Andrade <arthurfelandrade@gmail.com>

## What's the purpose of this pull request?

This PR fix the config from storeframework CMS to be possible adds the IncentivesHeader and BannerText variant.

## How does it work?

Fix sections.json config.

## How to test it?

View the [preview](https://sfj-7f9092f--gatsby.preview.vtex.app/) and use the [Storeframework CMS.]( https://storeframework.myvtex.com/admin/new-cms/faststore/home/edit/ad2fd81d-a53c-4281-8d01-a4fc2f274db3/)

## References

https://www.faststore.dev/tutorials/cms/3

## Checklist

<em>You may erase this after checking them all ;)</em>

**PR Title and Commit Messages**
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification
- [x] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification

**PR Description**
- [x] Added a label according to the PR goal - `Breaking change`, `Enhancement`, `Bug` or `Chore`.
- [ ] Added the component, hook, or pathname in-between backticks (``) *- If applicable*. E.g., *`ComponentName` component*.
- [ ] Identified the function or parameter in the PR *- If applicable*. E.g., *`useWindowDimensions` hook*.

**Documentation**
- [ ] PR description
- [ ] Added to/Updated the Storybook - *if applicable*.
- [ ] For documentation changes, ping @ carolinamenezes, @ PedroAntunesCosta or @ Mariana-Caetano to review and update.
