### PR TITLE
Feat: [Refinements] Creates `ShippingSimulation`

### DIFF
--- a/src/components/regionalization/Regionalization.stories.mdx
+++ b/src/components/regionalization/Regionalization.stories.mdx
@@ -46,7 +46,7 @@ Regionalization uses a behavior from VTEX Intelligent Search called [Availabilit
 
 Stores that have more than one registered white label seller usually have specific inventories for each region. This is the case for supermarkets, for example.
 
-With the Regionalization feature enabled, if a customer enters their ZIP code while browsing the store (before checkout), only products available in the corresponding region will be displayed in the search results.
+With the Regionalization feature enabled, if a customer enters their Postal Code while browsing the store (before checkout), only products available in the corresponding region will be displayed in the search results.
 
 ### Steps
 

--- a/src/components/regionalization/RegionalizationInput/RegionalizationInput.tsx
+++ b/src/components/regionalization/RegionalizationInput/RegionalizationInput.tsx
@@ -33,7 +33,7 @@ function RegionInput({ closeModal }: Props) {
 
       closeModal()
     } catch (error) {
-      setErrorMessage('You entered an invalid Zip Code')
+      setErrorMessage('You entered an invalid Postal Code')
     }
   }
 
@@ -43,7 +43,7 @@ function RegionInput({ closeModal }: Props) {
         inputRef={inputRef}
         id="postal-code-input"
         error={errorMessage}
-        label="Zip Code"
+        label="Postal Code"
         actionable
         value={input}
         onInput={(e) => {

--- a/src/components/regionalization/RegionalizationModal/RegionalizationModalContent.tsx
+++ b/src/components/regionalization/RegionalizationModal/RegionalizationModalContent.tsx
@@ -39,7 +39,7 @@ function RegionalizationModalContent({
           <RegionalizationInput closeModal={() => onClose?.()} />
         </div>
         <Link href="/" data-fs-regionalization-modal-link>
-          {"Don't know my Postal Code"}
+          {"I don't know my Postal Code"}
           <Icon name="ArrowSquareOut" width={18} height={18} />
         </Link>
       </div>

--- a/src/components/sections/ProductDetails/ProductDetails.tsx
+++ b/src/components/sections/ProductDetails/ProductDetails.tsx
@@ -9,6 +9,7 @@ import { ImageGallery } from 'src/components/ui/ImageGallery'
 import Price from 'src/components/ui/Price'
 import ProductTitle from 'src/components/ui/ProductTitle'
 import QuantitySelector from 'src/components/ui/QuantitySelector'
+import ShippingSimulation from 'src/components/ui/ShippingSimulation'
 import { useBuyButton } from 'src/sdk/cart/useBuyButton'
 import { useFormattedPrice } from 'src/sdk/product/useFormattedPrice'
 import { useProduct } from 'src/sdk/product/useProduct'
@@ -180,6 +181,8 @@ function ProductDetails({ product: staleProduct }: Props) {
             />
           )}
         </section>
+
+        <ShippingSimulation />
 
         <section className="product-details__content">
           <article className="product-details__description">

--- a/src/components/sections/ProductDetails/product-details.scss
+++ b/src/components/sections/ProductDetails/product-details.scss
@@ -16,7 +16,7 @@
 
   @include media(">=tablet") {
     display: grid;
-    grid-template-rows: repeat(4, minmax(0, max-content));
+    grid-template-rows: repeat(2, minmax(0, min-content)) 270px minmax(0, max-content);
     grid-template-columns: repeat(12, 1fr);
     row-gap: 0;
     column-gap: var(--fs-spacing-4);
@@ -66,12 +66,12 @@
   }
 
   @include media(">=tablet") {
-    grid-row: 2 / span 3;
+    grid-row: 2;
     grid-column: 8 / span 5;
+    height: 100%;
     padding: var(--fs-spacing-5);
     border: var(--fs-border-width) solid var(--fs-border-color-light);
     border-top: 0;
-    border-radius: 0 0 var(--fs-border-radius) var(--fs-border-radius);
   }
 
   @include media(">=notebook") { grid-column: 9 / span 4; }

--- a/src/components/ui/ImageGallery/image-gallery.module.scss
+++ b/src/components/ui/ImageGallery/image-gallery.module.scss
@@ -24,7 +24,7 @@
 
   @include media(">=tablet") {
     left: 0;
-    grid-row: 1 / span 2;
+    grid-row: 1 / span 3;
     grid-column: span 7;
     width: 100%;
     margin-bottom: var(--fs-spacing-7);

--- a/src/components/ui/InputText/InputText.tsx
+++ b/src/components/ui/InputText/InputText.tsx
@@ -35,6 +35,7 @@ type ActionableInputText =
       onSubmit?: never
       onClear?: never
       buttonActionText?: string
+      displayClearButton?: never
     }
   | {
       /**
@@ -53,6 +54,10 @@ type ActionableInputText =
        * The text displayed on the Button. Suggestion: maximum 9 characters.
        */
       buttonActionText?: string
+      /**
+       * Boolean that controls the clear button.
+       */
+      displayClearButton?: boolean
     }
 
 export type InputTextProps = DefaultProps &
@@ -64,6 +69,7 @@ const InputText = ({
   label,
   type = 'text',
   error,
+  displayClearButton,
   actionable,
   buttonActionText = 'Apply',
   onSubmit,
@@ -96,7 +102,7 @@ const InputText = ({
       <UILabel htmlFor={id}>{label}</UILabel>
 
       {shouldDisplayButton &&
-        (error ? (
+        (displayClearButton || error ? (
           <Button
             variant="tertiary"
             data-fs-button-icon

--- a/src/components/ui/ShippingSimulation/ShippingSimulation.stories.mdx
+++ b/src/components/ui/ShippingSimulation/ShippingSimulation.stories.mdx
@@ -1,0 +1,153 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/addon-docs'
+import ShippingSimulation from '.'
+import {
+  TokenTable,
+  TokenRow,
+  TokenDivider,
+} from 'src/../.storybook/components'
+
+<Meta
+  title="Features/ShippingSimulation"
+  component={ShippingSimulation}
+  argTypes={{
+    testId: {
+      table: {
+        disable: true,
+      },
+    },
+  }}
+/>
+
+export const TemplateProvider = (args) => {
+  return <ShippingSimulation {...args} style={{ border: 0 }} />
+}
+
+<header>
+
+# Shipping Simulation
+
+This feature lets customers set the `PostalCode` and see the shipping options in the `PDP`.
+
+</header>
+
+## Overview
+
+The `ShippingSimulation` component uses [FastStore UI Table](https://www.faststore.dev/reference/ui/molecules/Table), and [InputText](/docs/atoms-inputtext-⚠%EF%B8%8F--default) as base.
+
+### Steps
+
+1. First, the available `ShippingSimulation` loads if any `PostalCode` is set using the [Regionalization](/docs/features-regionalization-overview--default-button).
+2. If there is no `PostalCode` in the [Regionalization](/docs/features-regionalization-overview--default-button), the user can set the desired shipping `PostalCode`.
+3. Updates `ShippingSimulation`.
+4. Gets notified if there are no available options.
+
+---
+
+## Usage
+
+`import ShippingSimulation from 'src/components/ui/ShippingSimulation'`
+
+<Canvas>
+  <Story name="default">{TemplateProvider.bind({})}</Story>
+</Canvas>
+
+<TokenTable>
+  <TokenRow
+    token="--fs-shipping-simulation-font-size"
+    value="var(--fs-text-size-legend)"
+  />
+  <TokenDivider />
+  <TokenRow
+    token="--fs-shipping-simulation-padding"
+    value="var(--fs-spacing-5)"
+  />
+  <TokenRow
+    token="--fs-shipping-simulation-border-width"
+    value="var(--fs-border-width)"
+  />
+  <TokenRow
+    token="--fs-shipping-simulation-border-color"
+    value="var(--fs-border-color-light)"
+    isColor
+  />
+  <TokenRow
+    token="--fs-shipping-simulation-border-radius-bottom"
+    value="var(--fs-border-radius)"
+  />
+</TokenTable>
+
+---
+
+## Nested Elements
+
+### Title
+
+<TokenTable>
+  <TokenRow
+    token="--fs-shipping-simulation-title-padding-bottom"
+    value="var(--fs-spacing-2)"
+  />
+</TokenTable>
+
+### Link
+
+<TokenTable>
+  <TokenRow
+    token="--fs-shipping-simulation-link-padding-top"
+    value="var(--fs-spacing-1)"
+  />
+  <TokenRow
+    token="--fs-shipping-simulation-link-padding-bottom"
+    value="var(--fs-spacing-4)"
+  />
+</TokenTable>
+
+### Subtitle
+
+<TokenTable>
+  <TokenRow
+    token="--fs-shipping-simulation-subtitle-text-size"
+    value="var(--fs-text-size-2)"
+  />
+  <TokenRow
+    token="--fs-shipping-simulation-subtitle-text-weight"
+    value="var(--fs-text-weight-bold)"
+  />
+  <TokenRow token="--fs-shipping-simulation-subtitle-line-height" value="1.5" />
+</TokenTable>
+
+### Location
+
+<TokenTable>
+  <TokenRow
+    token="--fs-shipping-simulation-location-padding-bottom"
+    value="var(--fs-spacing-2)"
+  />
+</TokenTable>
+
+### Table
+
+<TokenTable>
+  <TokenRow
+    token="--fs-shipping-simulation-table-row-bkg-color"
+    value="var(--fs-color-main-0)"
+    isColor
+  />
+  <TokenRow
+    token="--fs-shipping-simulation-table-row-even-bkg-color"
+    value="transparent"
+  />
+  <TokenDivider />
+  <TokenRow
+    token="--fs-shipping-simulation-table-cell-padding"
+    value="var(--fs-spacing-2)"
+  />
+  <TokenRow
+    token="--fs-shipping-simulation-table-cell-text-size"
+    value="var(--fs-text-size-2)"
+  />
+  <TokenRow
+    token="--fs-shipping-simulation-table-cell-border-radius"
+    value=".25rem"
+  />
+</TokenTable>

--- a/src/components/ui/ShippingSimulation/ShippingSimulation.stories.mdx
+++ b/src/components/ui/ShippingSimulation/ShippingSimulation.stories.mdx
@@ -53,7 +53,7 @@ The `ShippingSimulation` component uses [FastStore UI Table](https://www.faststo
 
 <TokenTable>
   <TokenRow
-    token="--fs-shipping-simulation-font-size"
+    token="--fs-shipping-simulation-text-size"
     value="var(--fs-text-size-legend)"
   />
   <TokenDivider />
@@ -106,11 +106,11 @@ The `ShippingSimulation` component uses [FastStore UI Table](https://www.faststo
 
 <TokenTable>
   <TokenRow
-    token="--fs-shipping-simulation-subtitle-text-size"
+    token="--fs-shipping-simulation-subtitle-size"
     value="var(--fs-text-size-2)"
   />
   <TokenRow
-    token="--fs-shipping-simulation-subtitle-text-weight"
+    token="--fs-shipping-simulation-subtitle-weight"
     value="var(--fs-text-weight-bold)"
   />
   <TokenRow token="--fs-shipping-simulation-subtitle-line-height" value="1.5" />

--- a/src/components/ui/ShippingSimulation/ShippingSimulation.tsx
+++ b/src/components/ui/ShippingSimulation/ShippingSimulation.tsx
@@ -1,0 +1,107 @@
+import { Table, TableBody, TableCell, TableRow } from '@faststore/ui'
+import type { HTMLAttributes } from 'react'
+
+import Price from 'src/components/ui/Price'
+import { usePriceFormatter } from 'src/sdk/product/useFormattedPrice'
+
+import Icon from '../Icon'
+import InputText from '../InputText'
+import Link from '../Link'
+import styles from './shipping-simulation.module.scss'
+import { useShippingSimulation } from './useShippingSimulation'
+
+interface ShippingSimulationProps extends HTMLAttributes<HTMLDivElement> {
+  /**
+   * ID to find this component in testing tools (e.g.: cypress,
+   * testing-library, and jest).
+   */
+  testId?: string
+}
+
+function ShippingSimulation({
+  testId = 'store-shipping-simulation',
+  ...otherProps
+}: ShippingSimulationProps) {
+  const { dispatch, input, shippingSimulation, handleSubmit, handleOnInput } =
+    useShippingSimulation()
+
+  const {
+    postalCode: shippingPostalCode,
+    displayClearButton,
+    errorMessage,
+  } = input
+
+  const { location: shippingLocation, options: shippingOptions } =
+    shippingSimulation
+
+  const formatter = usePriceFormatter()
+
+  const hasShippingOptions = !!shippingOptions && shippingOptions.length > 0
+
+  return (
+    <section
+      className={styles.fsShippingSimulation}
+      data-fs-shipping-simulation
+      data-fs-shipping-simulation-empty={!hasShippingOptions ? 'true' : 'false'}
+      data-testid={testId}
+      {...otherProps}
+    >
+      <h2 className="text__title-subsection" data-fs-shipping-simulation-title>
+        Shipping
+      </h2>
+
+      <InputText
+        actionable
+        error={errorMessage}
+        id="shipping-postal-code"
+        label="Postal Code"
+        value={shippingPostalCode}
+        onInput={handleOnInput}
+        onSubmit={handleSubmit}
+        onClear={() => dispatch({ type: 'clear' })}
+        displayClearButton={displayClearButton}
+      />
+
+      <Link href="/" data-fs-shipping-simulation-link>
+        {"I don't know my Postal Code"}
+        <Icon name="ArrowSquareOut" width={18} height={18} />
+      </Link>
+
+      {hasShippingOptions && (
+        <>
+          <h3 data-fs-shipping-simulation-subtitle>Shipping options</h3>
+          <p className="text__body" data-fs-shipping-simulation-location>
+            {shippingLocation}
+          </p>
+
+          <Table data-fs-shipping-simulation-table>
+            <TableBody>
+              {shippingOptions.map((option) => (
+                <TableRow
+                  key={option.carrier}
+                  data-fs-shipping-simulation-table-row
+                >
+                  <TableCell data-fs-shipping-simulation-table-cell>
+                    {option.carrier}
+                  </TableCell>
+                  <TableCell data-fs-shipping-simulation-table-cell>
+                    {option.estimate}
+                  </TableCell>
+                  <TableCell data-fs-shipping-simulation-table-cell>
+                    <Price
+                      formatter={formatter}
+                      value={option.price}
+                      SRText="price"
+                    />
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </>
+      )}
+    </section>
+  )
+}
+
+export default ShippingSimulation

--- a/src/components/ui/ShippingSimulation/index.tsx
+++ b/src/components/ui/ShippingSimulation/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './ShippingSimulation'

--- a/src/components/ui/ShippingSimulation/shipping-simulation.module.scss
+++ b/src/components/ui/ShippingSimulation/shipping-simulation.module.scss
@@ -22,8 +22,8 @@
   --fs-shipping-simulation-link-padding-bottom      : var(--fs-spacing-4);
 
   // Subtitle
-  --fs-shipping-simulation-subtitle-size       : var(--fs-text-size-2);
-  --fs-shipping-simulation-subtitle-weight     : var(--fs-text-weight-bold);
+  --fs-shipping-simulation-subtitle-size            : var(--fs-text-size-2);
+  --fs-shipping-simulation-subtitle-weight          : var(--fs-text-weight-bold);
   --fs-shipping-simulation-subtitle-line-height     : 1.5;
 
   // Location

--- a/src/components/ui/ShippingSimulation/shipping-simulation.module.scss
+++ b/src/components/ui/ShippingSimulation/shipping-simulation.module.scss
@@ -1,0 +1,111 @@
+@import "src/styles/scaffold";
+
+.fs-shipping-simulation {
+  // --------------------------------------------------------
+  // Design Tokens for Shipping Simulation
+  // --------------------------------------------------------
+
+  // Default properties
+  --fs-shipping-simulation-font-size                : var(--fs-text-size-legend);
+
+  --fs-shipping-simulation-padding                  : var(--fs-spacing-5);
+
+  --fs-shipping-simulation-border-width             : var(--fs-border-width);
+  --fs-shipping-simulation-border-color             : var(--fs-border-color-light);
+  --fs-shipping-simulation-border-radius-bottom     : var(--fs-border-radius);
+
+  // Title
+  --fs-shipping-simulation-title-padding-bottom     : var(--fs-spacing-2);
+
+  // Link
+  --fs-shipping-simulation-link-padding-top         : var(--fs-spacing-1);
+  --fs-shipping-simulation-link-padding-bottom      : var(--fs-spacing-4);
+
+  // Subtitle
+  --fs-shipping-simulation-subtitle-text-size       : var(--fs-text-size-2);
+  --fs-shipping-simulation-subtitle-text-weight     : var(--fs-text-weight-bold);
+  --fs-shipping-simulation-subtitle-line-height     : 1.5;
+
+  // Location
+  --fs-shipping-simulation-location-padding-bottom  : var(--fs-spacing-2);
+
+  // Table
+  --fs-shipping-simulation-table-row-bkg-color      : var(--fs-color-main-0);
+  --fs-shipping-simulation-table-row-even-bkg-color : transparent;
+
+  --fs-shipping-simulation-table-cell-padding       : var(--fs-spacing-2);
+  --fs-shipping-simulation-table-cell-text-size     : var(--fs-text-size-2);
+  --fs-shipping-simulation-table-cell-border-radius : .25rem;
+
+  font-size: var(--fs-shipping-simulation-font-size);
+
+  @include media(">=tablet") {
+    grid-row: 3 / span 2;
+    grid-column: 8 / span 5;
+    padding: var(--fs-shipping-simulation-padding);
+    border: var(--fs-shipping-simulation-border-width) solid var(--fs-shipping-simulation-border-color);
+    border-top: 0;
+    border-bottom-right-radius: var(--fs-shipping-simulation-border-radius-bottom);
+    border-bottom-left-radius: var(--fs-shipping-simulation-border-radius-bottom);
+  }
+
+  @include media(">=notebook") { grid-column: 9 / span 4; }
+
+  &[data-fs-shipping-simulation-empty="true"] {
+    grid-row: 3;
+  }
+
+  [data-fs-shipping-simulation-title] {
+    padding-bottom: var(--fs-shipping-simulation-title-padding-bottom);
+  }
+
+  [data-fs-shipping-simulation-link] {
+    display: flex;
+    align-items: center;
+    padding-top: var(--fs-shipping-simulation-link-padding-top);
+    padding-bottom: var(--fs-shipping-simulation-link-padding-bottom);
+
+    svg {
+      margin-left: var(--fs-spacing-0);
+    }
+  }
+
+  [data-fs-shipping-simulation-subtitle] {
+    font-size: var(--fs-shipping-simulation-subtitle-text-size);
+    font-weight: var(--fs-shipping-simulation-subtitle-text-weight);
+    line-height: var(--fs-shipping-simulation-subtitle-line-height);
+  }
+
+  [data-fs-shipping-simulation-location] {
+    padding-bottom: var(--fs-shipping-simulation-location-padding-bottom);
+  }
+
+  [data-fs-shipping-simulation-table] {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  [data-fs-shipping-simulation-table-row] {
+    background-color: var(--fs-shipping-simulation-table-row-bkg-color);
+
+    &:nth-child(even) {
+      background-color: var(--fs-shipping-simulation-table-row-even-bkg-color);
+    }
+  }
+
+  [data-fs-shipping-simulation-table-cell] {
+    padding: var(--fs-shipping-simulation-table-cell-padding);
+    font-size: var(--fs-shipping-simulation-table-cell-text-size);
+
+    &:first-child {
+      border-top-left-radius: var(--fs-shipping-simulation-table-cell-border-radius);
+      border-bottom-left-radius: var(--fs-shipping-simulation-table-cell-border-radius);
+    }
+
+    &:last-child {
+      text-align: right;
+      border-top-right-radius: var(--fs-shipping-simulation-table-cell-border-radius);
+      border-bottom-right-radius: var(--fs-shipping-simulation-table-cell-border-radius);
+    }
+  }
+}

--- a/src/components/ui/ShippingSimulation/shipping-simulation.module.scss
+++ b/src/components/ui/ShippingSimulation/shipping-simulation.module.scss
@@ -6,7 +6,7 @@
   // --------------------------------------------------------
 
   // Default properties
-  --fs-shipping-simulation-font-size                : var(--fs-text-size-legend);
+  --fs-shipping-simulation-text-size                : var(--fs-text-size-legend);
 
   --fs-shipping-simulation-padding                  : var(--fs-spacing-5);
 
@@ -22,8 +22,8 @@
   --fs-shipping-simulation-link-padding-bottom      : var(--fs-spacing-4);
 
   // Subtitle
-  --fs-shipping-simulation-subtitle-text-size       : var(--fs-text-size-2);
-  --fs-shipping-simulation-subtitle-text-weight     : var(--fs-text-weight-bold);
+  --fs-shipping-simulation-subtitle-size       : var(--fs-text-size-2);
+  --fs-shipping-simulation-subtitle-weight     : var(--fs-text-weight-bold);
   --fs-shipping-simulation-subtitle-line-height     : 1.5;
 
   // Location
@@ -37,7 +37,7 @@
   --fs-shipping-simulation-table-cell-text-size     : var(--fs-text-size-2);
   --fs-shipping-simulation-table-cell-border-radius : .25rem;
 
-  font-size: var(--fs-shipping-simulation-font-size);
+  font-size: var(--fs-shipping-simulation-text-size);
 
   @include media(">=tablet") {
     grid-row: 3 / span 2;
@@ -71,8 +71,8 @@
   }
 
   [data-fs-shipping-simulation-subtitle] {
-    font-size: var(--fs-shipping-simulation-subtitle-text-size);
-    font-weight: var(--fs-shipping-simulation-subtitle-text-weight);
+    font-size: var(--fs-shipping-simulation-subtitle-size);
+    font-weight: var(--fs-shipping-simulation-subtitle-weight);
     line-height: var(--fs-shipping-simulation-subtitle-line-height);
   }
 

--- a/src/components/ui/ShippingSimulation/useShippingSimulation.ts
+++ b/src/components/ui/ShippingSimulation/useShippingSimulation.ts
@@ -1,0 +1,225 @@
+import type { ChangeEvent } from 'react'
+import { useCallback, useEffect, useReducer } from 'react'
+
+import { useSession } from 'src/sdk/session'
+
+type InputProps = {
+  postalCode?: string
+  displayClearButton?: boolean
+  errorMessage?: string
+}
+
+type ShippingOptionProps = {
+  carrier: string
+  estimate: string
+  price: number
+}
+
+type ShippingSimulationProps = {
+  location?: string
+  options?: ShippingOptionProps[]
+}
+
+type State = {
+  input: InputProps
+  shippingSimulation: ShippingSimulationProps
+}
+
+type Action =
+  | {
+      type: 'update'
+      payload: State
+    }
+  | {
+      type: 'onInput'
+      payload: InputProps
+    }
+  | {
+      type: 'onError'
+      payload: Partial<InputProps>
+    }
+  | {
+      type: 'clear'
+    }
+
+// TODO Remove Mocked data after API integration
+const mockShippingOptions: ShippingOptionProps[] = [
+  {
+    carrier: 'Regular',
+    estimate: '12 days',
+    price: 21,
+  },
+  {
+    carrier: 'Fedex',
+    estimate: '12 days',
+    price: 23,
+  },
+  {
+    carrier: 'Same day',
+    estimate: '1 day',
+    price: 89,
+  },
+  {
+    carrier: 'DHL',
+    estimate: '1 day',
+    price: 100,
+  },
+]
+
+const mockShippingSimulation: ShippingSimulationProps = {
+  location: 'Street Default — Newark, NY',
+  options: mockShippingOptions,
+}
+
+const createEmptySimulation = () => ({
+  input: {
+    postalCode: '',
+    displayClearButton: false,
+    errorMessage: '',
+  },
+  shippingSimulation: {
+    location: '',
+    options: [],
+  },
+})
+
+const reducer = (state: State, action: Action) => {
+  const { type } = action
+
+  switch (type) {
+    case 'clear': {
+      return createEmptySimulation()
+    }
+
+    case 'update': {
+      const { payload } = action
+
+      return {
+        input: {
+          ...state.input,
+          ...payload.input,
+        },
+        shippingSimulation: {
+          ...state.shippingSimulation,
+          ...payload.shippingSimulation,
+        },
+      }
+    }
+
+    case 'onInput': {
+      const { payload } = action
+
+      return {
+        ...state,
+        input: {
+          ...payload,
+        },
+      }
+    }
+
+    case 'onError': {
+      const { payload } = action
+
+      return {
+        ...state,
+        input: {
+          ...state.input,
+          ...payload,
+        },
+      }
+    }
+
+    default:
+      throw new Error(`Action ${type} not implemented`)
+  }
+}
+
+export const useShippingSimulation = () => {
+  const { postalCode: sessionPostalCode } = useSession()
+  const [{ input, shippingSimulation }, dispatch] = useReducer(
+    reducer,
+    null,
+    createEmptySimulation
+  )
+
+  const { postalCode: shippingPostalCode } = input
+
+  useEffect(() => {
+    if (!sessionPostalCode || shippingPostalCode) {
+      return
+    }
+
+    // Use sessionPostalCode if there is no shippingPostalCode
+    // TODO update mock after API integration
+    dispatch({
+      type: 'update',
+      payload: {
+        input: {
+          postalCode: sessionPostalCode,
+          displayClearButton: true,
+          errorMessage: '',
+        },
+        shippingSimulation: {
+          location: mockShippingSimulation?.location,
+          options: mockShippingSimulation?.options ?? [],
+        },
+      },
+    })
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sessionPostalCode])
+
+  const handleSubmit = useCallback(() => {
+    try {
+      // TODO update mock after API integration
+      dispatch({
+        type: 'update',
+        payload: {
+          input: {
+            displayClearButton: true,
+            errorMessage: '',
+          },
+          shippingSimulation: {
+            location: `Street from ${shippingPostalCode} Postal Code.`,
+            options: mockShippingOptions ?? [],
+          },
+        },
+      })
+    } catch (error) {
+      dispatch({
+        type: 'onError',
+        payload: {
+          displayClearButton: true,
+          errorMessage: 'You entered an invalid Postal Code',
+        },
+      })
+    }
+  }, [shippingPostalCode])
+
+  const handleOnInput = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+    const currentValue = e.currentTarget.value
+
+    if (currentValue) {
+      dispatch({
+        type: 'onInput',
+        payload: {
+          postalCode: currentValue,
+          displayClearButton: false,
+          errorMessage: '',
+        },
+      })
+    } else {
+      dispatch({
+        type: 'clear',
+      })
+    }
+  }, [])
+
+  return {
+    input,
+    shippingSimulation,
+    dispatch,
+    handleSubmit,
+    handleOnInput,
+  }
+}


### PR DESCRIPTION
> Ported from `nextjs.store` repo: [Feat: [Refinements] Creates ShippingSimulation #183](https://github.com/vtex-sites/nextjs.store/pull/183)

## What's the purpose of this pull request?

This PR aims to create and refine the `ShippingSimulation` that is found in the PDP.
**This task didn't include API integration**. Thus, we are using mocked data just to see the component working as expected.

---
Tasks:

 - [x] Creates Shipping Simulation.
 - [x] CSS Modules. 
 - [x] Themification.
 - [x]  Storybook.


## How does it work?

|Desktop|Mobile|
|-|-|
|![06VzGVSK2e](https://user-images.githubusercontent.com/11325562/181630177-b552834f-ed82-46e4-a2ff-f15ccdb2bd93.gif)|![mobile-shipping-simulation](https://user-images.githubusercontent.com/11325562/181629024-90b4ef96-48b8-43fc-8355-2bbeae2cec3a.gif)|

👀  One behavior to pay attention to: 
- if the user had a `PostalCode` included in its session, the page should load this `PostalCode` in the `ShippingSimulation` as the default.
- if the user sets the `PostalCode` in its session while in the `PDP` using the `Regionalization` feature, the page should load this `PostalCode` only if there is no `PostalCode` included in the `ShippingSimulation`.  But as we don't save the `PostalCode` from the `ShippingSimulation`, if the user refreshes the page, the one from the session must override the other from the `ShippingSimulation`.

![7rxQ0BdqYo](https://user-images.githubusercontent.com/11325562/181630967-e402fff6-43c7-4f5b-a9a7-8ce9ecf8a352.gif)

## How to test it?

So far, we are using mocked data, but you can play around inside the `PDP`. If something didn't work properly (because we are using a user session), try to clean the `IndexDB` data.

You can also see the storybook.

## References

https://www.figma.com/file/EYJqnbWByrSX9EMKvBzBLm/22%2F06%2F14-Handoff-for-PDP-Components?node-id=1001%3A131786
https://www.figma.com/file/EYJqnbWByrSX9EMKvBzBLm/22%2F06%2F14-Handoff-for-PDP-Components?node-id=1001%3A152727
https://vtex-dev.atlassian.net/jira/software/projects/FS/boards/632?selectedIssue=FS-475

## Checklist

<em>You may erase this after checking them all ;)</em>

**Changelog**
- [x] Added an entry in the `CHANGELOG.md` at the beginning of its due section. [The latest version should come first](https://keepachangelog.com/en/1.0.0/#:~:text=The%20latest%20version%20comes%20first.).
- [x] Added the PR number with the PR link at the entry in the `CHANGELOG.md`. E.g., *New items in the `pull_request_template.md` ([#4](https://github.com/vtex-sites/nextjs.store/pull/4))* 

**PR Description**
- [x] Added a label according to the PR goal - `Breaking change`, `Enhancement`, `Bug` or `Chore`.
- [x] Added the component, hook, or pathname in-between backticks (``) *- If applicable*. E.g., *`ComponentName` component*.
- [x] Identified the function or parameter in the PR *- If applicable*. E.g., *`useWindowDimensions` hook*.

**Documentation**
- [x] PR description
- [x] Added to/Updated the Storybook - *if applicable*.
- [ ] For documentation changes, ping @ carolinamenezes or @ PedroAntunesCosta to review and update.

