### PR TITLE
chore: Renames data-attr

### DIFF
--- a/src/components/cart/CartToggle/CartToggle.tsx
+++ b/src/components/cart/CartToggle/CartToggle.tsx
@@ -9,7 +9,7 @@ function CartToggle() {
     <Button
       variant="tertiary"
       data-fs-button-icon
-      data-fs-button-cart
+      data-fs-cart-toggle
       aria-label={`Cart with ${btnProps['data-items']} items`}
       icon={<Icon name="ShoppingCart" width={32} height={32} />}
       {...btnProps}

--- a/src/components/cart/CartToggle/cart-toggle.scss
+++ b/src/components/cart/CartToggle/cart-toggle.scss
@@ -1,6 +1,6 @@
 @import "src/styles/scaffold";
 
-[data-fs-button-cart] {
+[data-fs-cart-toggle] {
   position: relative;
 
   &::after {

--- a/src/components/common/Navbar/navbar.module.scss
+++ b/src/components/common/Navbar/navbar.module.scss
@@ -98,11 +98,7 @@
     align-items: center;
     justify-content: flex-end;
 
-    [data-fs-button-collapse] {
-      margin-left: calc(-1 * var(--fs-spacing-3));
-    }
-
-    [data-fs-button-signin-link] + [data-fs-button-cart] {
+    [data-fs-button-signin-link] + [data-fs-cart-toggle] {
       @include media(">=notebook") {
         margin-left: var(--fs-spacing-3);
       }


### PR DESCRIPTION
ported from https://github.com/vtex-sites/nextjs.store/pull/276

## What's the purpose of this pull request?

Update CartToggle data-attr from data-fs-button-cart to data-fs-cart-toggle

## How to test it?

Everything should look the same.

## Checklist

<em>You may erase this after checking them all ;)</em>

**PR Title and Commit Messages**
- [ ] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification
- [ ] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification

**PR Description**
- [ ] Added a label according to the PR goal - `Breaking change`, `Enhancement`, `Bug` or `Chore`.
- [ ] Added the component, hook, or pathname in-between backticks (``) *- If applicable*. E.g., *`ComponentName` component*.
- [ ] Identified the function or parameter in the PR *- If applicable*. E.g., *`useWindowDimensions` hook*.

**Documentation**
- [ ] PR description
- [ ] Added to/Updated the Storybook - *if applicable*.
- [ ] For documentation changes, ping @ carolinamenezes, @ PedroAntunesCosta or @ Mariana-Caetano to review and update.
