### PR TITLE
Fix: chunk load analytics

### DIFF
--- a/src/sdk/analytics/index.tsx
+++ b/src/sdk/analytics/index.tsx
@@ -1,7 +1,7 @@
 import type { AnalyticsEvent } from '@faststore/sdk'
 import { useAnalyticsEvent } from '@faststore/sdk'
 
-import storeConfig from '../../../store.config'
+import sendEvent from './platform/vtex'
 
 if (typeof window !== 'undefined') {
   window.dataLayer = window.dataLayer ?? []
@@ -17,11 +17,7 @@ export const AnalyticsHandler = () => {
     window.dataLayer.push({ ecommerce: null })
     window.dataLayer.push({ event: event.name, ecommerce: event.params })
 
-    import(`./platform/${storeConfig.platform}`).then(
-      ({ default: sendEvent }) => {
-        sendEvent(event)
-      }
-    )
+    sendEvent(event)
   })
 
   return null

--- a/src/sdk/analytics/platform/vtex/search.ts
+++ b/src/sdk/analytics/platform/vtex/search.ts
@@ -72,6 +72,10 @@ const handleEvent = (event: AnalyticsEvent | SearchSelectItemEvent) => {
     return
   }
 
+  if (typeof window === 'undefined') {
+    return
+  }
+
   const url = new URL(event.params.url)
 
   if (!isFullTextSearch(url)) {
@@ -94,9 +98,11 @@ const handleEvent = (event: AnalyticsEvent | SearchSelectItemEvent) => {
   }
 }
 
-setInterval(
-  () => sendEvent({ type: 'session.ping' }),
-  60 * 1e3 /* One minute */
-)
+if (typeof window !== 'undefined') {
+  setInterval(
+    () => sendEvent({ type: 'session.ping' }),
+    60 * 1e3 /* One minute */
+  )
+}
 
 export default handleEvent


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR aims to address some `ChunkLoadError` from the analytics Provider that we got from some clients (sentry).

![image](https://user-images.githubusercontent.com/11325562/200613698-d80d206a-04ee-440c-a012-3c6393849a23.png)

## How does it work?

It looks like this dynamic import is bringing some `ChunkLoadError`. So we transformed it into a static import and added a guard clause to prevent Reference errors using the navigator object on the Server Side.

* We dynamically import for the sake of initial JS loading. Then we need to pay attention if LH scores keep high after these changes.

## How to test it?

The `ChunkLoadError` from the analytics module in sentry should decrease. Everything in the store should look the same. 

## References

https://github.com/gatsbyjs/gatsby/issues/18866
https://github.com/gatsbyjs/gatsby/pull/33032
https://github.com/gatsbyjs/gatsby/pull/34225/files
